### PR TITLE
CI experiment: verify urca dependency enforcement

### DIFF
--- a/stfroutineforecasting/DESCRIPTION
+++ b/stfroutineforecasting/DESCRIPTION
@@ -30,8 +30,7 @@ Imports:
     tibble,
     tidybayes,
     tidyr,
-    tidyselect,
-    urca
+    tidyselect
 Additional_repositories: https://hubverse-org.r-universe.dev
 Remotes:
     github::cdcgov/forecasttools,


### PR DESCRIPTION
Temporary negative-control PR. Do not merge.\n\nThis removes urca from stfroutineforecasting/DESCRIPTION while pipelines/fable/fit_fable.R still explicitly loads it. The purpose is to verify that the production-like hard-dependency installation in GitHub Actions no longer obtains urca transitively and that CI catches the missing declaration. This PR will be closed after the result is captured.