### PR TITLE
Streamline common data serialization

### DIFF
--- a/src/cfa/stf/routine/README.md
+++ b/src/cfa/stf/routine/README.md
@@ -142,7 +142,7 @@ See [`fable/fit_fable.R`](fable/fit_fable.R) for an R writer and EpiAutoGP's [`f
 
 ## 3. Declare input resolution and use hooks only where needed
 
-The base pipeline serializes daily ED-visit inputs by default.
+The base pipeline prepares and serializes daily ED-visit inputs by default.
 Override the `ed_visit_input_resolution` property with `"epiweekly"` when a model requires ED visits aggregated to complete MMWR weeks.
 The declared resolution applies consistently to both `combined_data.tsv` and `data_for_model_fit.json`.
 

--- a/src/cfa/stf/routine/README.md
+++ b/src/cfa/stf/routine/README.md
@@ -140,15 +140,18 @@ Additional identifiers such as `.chain`, `.iteration`, or `lab_site_index` are a
 Draws should form coherent trajectories: the same `.draw` identifies values belonging to one sample across forecast dates.
 See [`fable/fit_fable.R`](fable/fit_fable.R) for an R writer and EpiAutoGP's [`forecast_epiautogp.py`](epiautogp/forecast_epiautogp.py) for a non-R writer.
 
-## 3. Use hooks only where needed
+## 3. Declare input resolution and use hooks only where needed
 
-The base class provides optional hooks for model-specific input preparation:
+The base pipeline serializes daily ED-visit inputs by default.
+Override the `ed_visit_input_resolution` property with `"epiweekly"` when a model requires ED visits aggregated to complete MMWR weeks.
+The declared resolution applies consistently to both `combined_data.tsv` and `data_for_model_fit.json`.
 
-  | Hook                             | Use it to                                                |
-  | -------------------------------- | -------------------------------------------------------- |
-  | `validate_configuration()`       | Reject invalid option combinations before loading data   |
-  | `transform_serialized_data(run)` | Transform common data, such as epiweekly aggregation     |
-  | `prepare_model_artifacts(run)`   | Create model-specific inputs, such as JSON or parameters |
+The base class also provides optional hooks for model-specific preparation:
+
+  | Hook                           | Use it to                                                |
+  | ------------------------------ | -------------------------------------------------------- |
+  | `validate_configuration()`     | Reject invalid option combinations before loading data   |
+  | `prepare_model_artifacts(run)` | Create model-specific inputs, such as JSON or parameters |
 
 Do not override `execute()`, `build_forecast_run()`, `prepare_input_artifacts()`, or `publish_outputs()` unless the shared lifecycle itself must change.
 Keeping those methods common preserves data freshness checks and compatible outputs.

--- a/src/cfa/stf/routine/dagster_defs.py
+++ b/src/cfa/stf/routine/dagster_defs.py
@@ -35,6 +35,7 @@ from pyrenew_multisignal.hew.utils import flags_from_hew_letters
 
 # Model Code
 from cfa.stf.routine._paths import PRODUCTION_PRIORS
+from cfa.stf.routine.data.data_access import DataResolution
 from cfa.stf.routine.fable.forecast_fable import main as forecast_fable
 from cfa.stf.routine.pyrenew_hew.forecast_pyrenew import main as forecast_pyrenew
 from cfa.stf.routine.utils.date_utils import calculate_training_dates
@@ -332,11 +333,9 @@ def _run_fable_e_other(
     context: dg.OpExecutionContext,
     fable_e_other_config: FableEOtherConfig,
     model_base_config: ModelBaseConfig,
-    epiweekly: bool,
+    ed_visit_input_resolution: DataResolution,
 ) -> str | None:
-    """
-    Helper function to run fable E-other model with optional epiweekly mode.
-    """
+    """Run a Fable E-other model at the requested ED-visit resolution."""
     _throw_if_backfill(context, daily_partitions_def)
 
     disease = model_base_config.diseases.current_value
@@ -362,7 +361,7 @@ def _run_fable_e_other(
         n_forecast_days=28,
         n_samples=fable_e_other_config.n_samples,
         exclude_last_n_days=loc_config.exclude_last_n_days,
-        epiweekly=epiweekly,
+        ed_visit_input_resolution=ed_visit_input_resolution,
         run_date=run_date,
         fail_on_stale_data=model_base_config.fail_on_stale_data,
     )
@@ -637,7 +636,7 @@ def fable_e_other(
         context,
         fable_e_other_config,
         model_base_config,
-        epiweekly=False,
+        ed_visit_input_resolution="daily",
     )
 
 
@@ -655,7 +654,7 @@ def epiweekly_fable_e_other(
         context,
         fable_e_other_config,
         model_base_config,
-        epiweekly=True,
+        ed_visit_input_resolution="epiweekly",
     )
 
 

--- a/src/cfa/stf/routine/data/data_access.py
+++ b/src/cfa/stf/routine/data/data_access.py
@@ -13,6 +13,7 @@ from cfa.stf.data import (
 )
 from cfa.stf.forecasttools import get_us_loc_pop_tbl
 
+DataResolution = Literal["daily", "epiweekly"]
 ForecastSourceName = Literal["nssp", "nhsn"]
 _FORECAST_SOURCE_NAMES = frozenset(get_args(ForecastSourceName))
 

--- a/src/cfa/stf/routine/data/data_access.py
+++ b/src/cfa/stf/routine/data/data_access.py
@@ -2,7 +2,7 @@ import datetime as dt
 import logging
 from collections.abc import Collection
 from dataclasses import dataclass, replace
-from typing import Literal, get_args
+from typing import ClassVar, Literal, get_args
 
 import polars as pl
 from cfa.stf.data import (
@@ -17,6 +17,7 @@ from cfa.stf.routine.utils.data_utils import aggregate_nssp_to_epiweekly
 
 DataResolution = Literal["daily", "epiweekly"]
 ForecastSourceName = Literal["nssp", "nhsn"]
+_DATA_RESOLUTIONS = frozenset(get_args(DataResolution))
 _FORECAST_SOURCE_NAMES = frozenset(get_args(ForecastSourceName))
 
 
@@ -34,6 +35,18 @@ class DataFreshness:
 class ForecastSourceData:
     data: pl.DataFrame
     freshness: DataFreshness
+    resolution: DataResolution
+
+    def __post_init__(self) -> None:
+        if self.resolution not in _DATA_RESOLUTIONS:
+            raise ValueError(
+                f"Unsupported {type(self).__name__} resolution: {self.resolution}"
+            )
+
+    @property
+    def step_size(self) -> int:
+        """Number of days represented by one observation."""
+        return 7 if self.resolution == "epiweekly" else 1
 
 
 @dataclass(frozen=True)
@@ -43,6 +56,7 @@ class NSSPData(ForecastSourceData):
 
 @dataclass(frozen=True)
 class NHSNData(ForecastSourceData):
+    resolution: ClassVar[Literal["epiweekly"]] = "epiweekly"
     prelim: bool
 
 
@@ -124,7 +138,7 @@ def _load_dataops_nssp(
         .drop("total", "target_type")
         .sort("date")
     )
-    return NSSPData(data=data, freshness=freshness)
+    return NSSPData(data=data, freshness=freshness, resolution="daily")
 
 
 def select_latest_nhsn_release() -> tuple[bool, dt.date]:
@@ -178,7 +192,11 @@ def _load_dataops_nhsn(
             "resolution",
         )
     )
-    return NHSNData(data=data, freshness=freshness, prelim=prelim)
+    return NHSNData(
+        data=data,
+        freshness=freshness,
+        prelim=prelim,
+    )
 
 
 def nssp_freshness(
@@ -300,7 +318,11 @@ def load_surveillance_inputs(
         )
         if ed_visit_input_resolution == "epiweekly":
             logger.info("Aggregating ED visits to epiweekly resolution...")
-            nssp = replace(nssp, data=aggregate_nssp_to_epiweekly(nssp.data))
+            nssp = replace(
+                nssp,
+                data=aggregate_nssp_to_epiweekly(nssp.data),
+                resolution="epiweekly",
+            )
         freshness.append(nssp.freshness)
 
     if "nhsn" in requested_sources:

--- a/src/cfa/stf/routine/data/data_access.py
+++ b/src/cfa/stf/routine/data/data_access.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import logging
 from collections.abc import Collection
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal, get_args
 
 import polars as pl
@@ -12,6 +12,8 @@ from cfa.stf.data import (
     resolve_nssp_version,
 )
 from cfa.stf.forecasttools import get_us_loc_pop_tbl
+
+from cfa.stf.routine.utils.data_utils import aggregate_nssp_to_epiweekly
 
 DataResolution = Literal["daily", "epiweekly"]
 ForecastSourceName = Literal["nssp", "nhsn"]
@@ -273,6 +275,7 @@ def load_surveillance_inputs(
     first_training_date: dt.date,
     last_training_date: dt.date,
     sources: Collection[ForecastSourceName],
+    ed_visit_input_resolution: DataResolution = "daily",
     fail_on_stale_data: bool = False,
     logger: logging.Logger | None = None,
 ) -> SurveillanceInputs:
@@ -295,6 +298,9 @@ def load_surveillance_inputs(
             last_training_date=last_training_date,
             run_date=run_date,
         )
+        if ed_visit_input_resolution == "epiweekly":
+            logger.info("Aggregating ED visits to epiweekly resolution...")
+            nssp = replace(nssp, data=aggregate_nssp_to_epiweekly(nssp.data))
         freshness.append(nssp.freshness)
 
     if "nhsn" in requested_sources:

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -278,6 +278,7 @@ def make_surveillance_inputs(
                 .sort("date")
             ),
             freshness=nssp_freshness,
+            resolution="daily",
         )
         if "nssp" in requested_sources
         else None

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -28,19 +28,15 @@ def combine_surveillance_data(
                 variable_name=".variable",
                 index=cs.exclude(["observed_ed_visits", "other_ed_visits"]),
                 value_name=".value",
-            ).with_columns(pl.lit(None).alias("lab_site_index"))
+            )
         )
 
     if nhsn_data is not None:
         source_frames.append(
-            nhsn_data.unpivot(
-                on="value",
-                index=cs.exclude("value"),
-                variable_name=".variable",
-                value_name=".value",
-            ).with_columns(
+            nhsn_data.select(
+                cs.exclude("value"),
                 pl.lit("observed_hospital_admissions").alias(".variable"),
-                pl.lit(None).alias("lab_site_index"),
+                pl.col("value").alias(".value"),
             )
         )
 
@@ -53,7 +49,10 @@ def combine_surveillance_data(
             how="diagonal_relaxed",
         )
         .rename({"state_abb": "geo_value"})
-        .with_columns(pl.lit(disease).alias("disease"))
+        .with_columns(
+            pl.lit(disease).alias("disease"),
+            pl.lit(None).alias("lab_site_index"),
+        )
         .sort(["date", "geo_value", ".variable"])
         .select(
             [
@@ -77,8 +76,9 @@ def serialize_data(
     ed_visit_input_resolution: DataResolution = "daily",
 ) -> None:
     logger = logger or logging.getLogger(__name__)
+    save_dir = Path(save_dir)
 
-    Path(save_dir).mkdir(parents=True, exist_ok=True)
+    save_dir.mkdir(parents=True, exist_ok=True)
 
     nssp_data = forecast_run.nssp.data if forecast_run.nssp is not None else None
     nhsn_data = forecast_run.nhsn.data if forecast_run.nhsn is not None else None
@@ -126,7 +126,7 @@ def serialize_data(
         "nwss_step_size": 1,
     }
 
-    with open(Path(save_dir, "data_for_model_fit.json"), "w") as json_file:
+    with open(save_dir / "data_for_model_fit.json", "w") as json_file:
         json.dump(data_for_model_fit, json_file, default=str)
 
     combined_data = combine_surveillance_data(
@@ -137,7 +137,6 @@ def serialize_data(
     if nssp_data is not None:
         combined_data = append_prop_ed_data(combined_data)
 
-    logger.info(f"Saving {forecast_run.loc} to {save_dir}")
+    logger.info("Saving %s to %s", forecast_run.loc, save_dir)
 
-    combined_data.write_csv(Path(save_dir, "combined_data.tsv"), separator="\t")
-    return None
+    combined_data.write_csv(save_dir / "combined_data.tsv", separator="\t")

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -1,10 +1,13 @@
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import polars as pl
 import polars.selectors as cs
+
+from cfa.stf.routine.utils.data_utils import aggregate_ed_visits_to_epiweekly
+from cfa.stf.routine.utils.prop_utils import append_prop_data_to_combined_data
 
 if TYPE_CHECKING:
     from cfa.stf.routine.forecast_run import ForecastRun
@@ -75,59 +78,72 @@ def serialize_data(
     forecast_run: "ForecastRun",
     save_dir: Path,
     logger: logging.Logger | None = None,
+    ed_visit_input_resolution: Literal["daily", "epiweekly"] = "daily",
 ) -> None:
     logger = logger or logging.getLogger(__name__)
 
     Path(save_dir).mkdir(parents=True, exist_ok=True)
-
-    nssp_training_data = (
-        forecast_run.nssp.data.filter(pl.col("data_type") == "train")
-        if forecast_run.nssp is not None
-        else None
-    )
-    nhsn_training_data = (
-        forecast_run.nhsn.data.filter(pl.col("data_type") == "train")
-        if forecast_run.nhsn is not None
-        else None
-    )
-
-    data_for_model_fit = {
-        "loc_pop": forecast_run.loc_pop,
-        "right_truncation_offset": forecast_run.right_truncation_offset,
-        "nwss_training_data": None,
-        "nssp_training_data": (
-            nssp_training_data.drop("resolution", "data_type")
-            .rename({"state_abb": "geo_value"})
-            .to_dict(as_series=False)
-            if nssp_training_data is not None
-            else None
-        ),
-        "nhsn_training_data": (
-            nhsn_training_data.drop("resolution", "data_type")
-            .rename(
-                {
-                    "date": "weekendingdate",
-                    "state_abb": "jurisdiction",
-                    "value": "hospital_admissions",
-                }
-            )
-            .to_dict(as_series=False)
-            if nhsn_training_data is not None
-            else None
-        ),
-        "nhsn_step_size": 7,
-        "nssp_step_size": 1,
-        "nwss_step_size": 1,
-    }
-
-    with open(Path(save_dir, "data_for_model_fit.json"), "w") as json_file:
-        json.dump(data_for_model_fit, json_file, default=str)
 
     combined_data = combine_surveillance_data(
         disease=forecast_run.disease,
         nssp_data=forecast_run.nssp.data if forecast_run.nssp is not None else None,
         nhsn_data=forecast_run.nhsn.data if forecast_run.nhsn is not None else None,
     )
+    if ed_visit_input_resolution == "epiweekly":
+        logger.info("Aggregating ED visits to epiweekly resolution...")
+        combined_data = aggregate_ed_visits_to_epiweekly(combined_data)
+
+    training_data = combined_data.filter(pl.col("data_type") == "train")
+
+    nssp_training_data = None
+    if forecast_run.nssp is not None:
+        nssp_training_data = (
+            training_data.filter(
+                pl.col(".variable").is_in(["observed_ed_visits", "other_ed_visits"])
+            )
+            .pivot(on=".variable", index=["date", "geo_value"], values=".value")
+            .select(
+                "date",
+                "geo_value",
+                "observed_ed_visits",
+                "other_ed_visits",
+            )
+            .sort("date", "geo_value")
+        )
+
+    nhsn_training_data = None
+    if forecast_run.nhsn is not None:
+        nhsn_training_data = training_data.filter(
+            pl.col(".variable") == "observed_hospital_admissions"
+        ).select(
+            pl.col("date").alias("weekendingdate"),
+            pl.col("geo_value").alias("jurisdiction"),
+            pl.col(".value").alias("hospital_admissions"),
+        )
+
+    data_for_model_fit = {
+        "loc_pop": forecast_run.loc_pop,
+        "right_truncation_offset": forecast_run.right_truncation_offset,
+        "nwss_training_data": None,
+        "nssp_training_data": (
+            nssp_training_data.to_dict(as_series=False)
+            if nssp_training_data is not None
+            else None
+        ),
+        "nhsn_training_data": (
+            nhsn_training_data.to_dict(as_series=False)
+            if nhsn_training_data is not None
+            else None
+        ),
+        "nhsn_step_size": 7,
+        "nssp_step_size": 7 if ed_visit_input_resolution == "epiweekly" else 1,
+        "nwss_step_size": 1,
+    }
+
+    with open(Path(save_dir, "data_for_model_fit.json"), "w") as json_file:
+        json.dump(data_for_model_fit, json_file, default=str)
+
+    combined_data = append_prop_data_to_combined_data(combined_data)
 
     logger.info(f"Saving {forecast_run.loc} to {save_dir}")
 

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -23,31 +23,25 @@ def combine_surveillance_data(
     source_frames = []
     if nssp_data is not None:
         source_frames.append(
-            nssp_data.rename({"state_abb": "geo_value"})
-            .unpivot(
+            nssp_data.unpivot(
                 on=["observed_ed_visits", "other_ed_visits"],
                 variable_name=".variable",
                 index=cs.exclude(["observed_ed_visits", "other_ed_visits"]),
                 value_name=".value",
-            )
-            .with_columns(pl.lit(None).alias("lab_site_index"))
+            ).with_columns(pl.lit(None).alias("lab_site_index"))
         )
 
     if nhsn_data is not None:
         source_frames.append(
-            nhsn_data.rename(
-                {
-                    "state_abb": "geo_value",
-                    "value": "observed_hospital_admissions",
-                }
-            )
-            .unpivot(
-                on="observed_hospital_admissions",
-                index=cs.exclude("observed_hospital_admissions"),
+            nhsn_data.unpivot(
+                on="value",
+                index=cs.exclude("value"),
                 variable_name=".variable",
                 value_name=".value",
+            ).with_columns(
+                pl.lit("observed_hospital_admissions").alias(".variable"),
+                pl.lit(None).alias("lab_site_index"),
             )
-            .with_columns(pl.lit(None).alias("lab_site_index"))
         )
 
     if not source_frames:
@@ -58,6 +52,7 @@ def combine_surveillance_data(
             source_frames,
             how="diagonal_relaxed",
         )
+        .rename({"state_abb": "geo_value"})
         .with_columns(pl.lit(disease).alias("disease"))
         .sort(["date", "geo_value", ".variable"])
         .select(

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -1,11 +1,12 @@
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import polars as pl
 import polars.selectors as cs
 
+from cfa.stf.routine.data.data_access import DataResolution
 from cfa.stf.routine.utils.data_utils import aggregate_ed_visits_to_epiweekly
 from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
@@ -78,7 +79,7 @@ def serialize_data(
     forecast_run: "ForecastRun",
     save_dir: Path,
     logger: logging.Logger | None = None,
-    ed_visit_input_resolution: Literal["daily", "epiweekly"] = "daily",
+    ed_visit_input_resolution: DataResolution = "daily",
 ) -> None:
     logger = logger or logging.getLogger(__name__)
 

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -115,8 +115,8 @@ def serialize_data(
             if nhsn_training_data is not None
             else None
         ),
-        "nhsn_step_size": nhsn.step_size if nhsn is not None else 7,
-        "nssp_step_size": nssp.step_size if nssp is not None else 1,
+        "nhsn_step_size": nhsn.step_size if nhsn is not None else None,
+        "nssp_step_size": nssp.step_size if nssp is not None else None,
         "nwss_step_size": 1,
     }
 

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -6,7 +6,6 @@ import polars as pl
 import polars.selectors as cs
 
 from cfa.stf.routine.data.data_access import DataResolution
-from cfa.stf.routine.utils.data_utils import aggregate_nssp_to_epiweekly
 from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
 if TYPE_CHECKING:
@@ -80,9 +79,6 @@ def serialize_data(
 
     nssp_data = forecast_run.nssp.data if forecast_run.nssp is not None else None
     nhsn_data = forecast_run.nhsn.data if forecast_run.nhsn is not None else None
-    if nssp_data is not None and ed_visit_input_resolution == "epiweekly":
-        logger.info("Aggregating ED visits to epiweekly resolution...")
-        nssp_data = aggregate_nssp_to_epiweekly(nssp_data)
 
     nssp_training_data = (
         nssp_data.filter(pl.col("data_type") == "train")

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -30,10 +30,8 @@ def combine_surveillance_data(
 
     if nhsn_data is not None:
         source_frames.append(
-            nhsn_data.select(
-                cs.exclude("value"),
+            nhsn_data.rename({"value": ".value"}).with_columns(
                 pl.lit("observed_hospital_admissions").alias(".variable"),
-                pl.col("value").alias(".value"),
             )
         )
 

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -71,12 +70,11 @@ def combine_surveillance_data(
 
 def serialize_data(
     forecast_run: "ForecastRun",
-    save_dir: Path,
     logger: logging.Logger | None = None,
     ed_visit_input_resolution: DataResolution = "daily",
 ) -> None:
     logger = logger or logging.getLogger(__name__)
-    save_dir = Path(save_dir)
+    save_dir = forecast_run.data_dir
 
     save_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import polars as pl
 import polars.selectors as cs
 
-from cfa.stf.routine.data.data_access import DataResolution
 from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
 if TYPE_CHECKING:
@@ -70,15 +69,16 @@ def combine_surveillance_data(
 def serialize_data(
     forecast_run: "ForecastRun",
     logger: logging.Logger | None = None,
-    ed_visit_input_resolution: DataResolution = "daily",
 ) -> None:
     logger = logger or logging.getLogger(__name__)
     save_dir = forecast_run.data_dir
 
     save_dir.mkdir(parents=True, exist_ok=True)
 
-    nssp_data = forecast_run.nssp.data if forecast_run.nssp is not None else None
-    nhsn_data = forecast_run.nhsn.data if forecast_run.nhsn is not None else None
+    nssp = forecast_run.nssp
+    nssp_data = nssp.data if nssp is not None else None
+    nhsn = forecast_run.nhsn
+    nhsn_data = nhsn.data if nhsn is not None else None
 
     nssp_training_data = (
         nssp_data.filter(pl.col("data_type") == "train")
@@ -115,8 +115,8 @@ def serialize_data(
             if nhsn_training_data is not None
             else None
         ),
-        "nhsn_step_size": 7,
-        "nssp_step_size": 7 if ed_visit_input_resolution == "epiweekly" else 1,
+        "nhsn_step_size": nhsn.step_size if nhsn is not None else 7,
+        "nssp_step_size": nssp.step_size if nssp is not None else 1,
         "nwss_step_size": 1,
     }
 

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -128,6 +128,6 @@ def serialize_data(
     if forecast_run.nssp is not None:
         combined_data = append_prop_ed_data(combined_data)
 
-    logger.info("Saving %s to %s", forecast_run.loc, save_dir)
+    logger.info(f"Saving {forecast_run.loc} to {save_dir}")
 
     combined_data.write_csv(save_dir / "combined_data.tsv", separator="\t")

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -73,20 +73,15 @@ def serialize_data(
 
     save_dir.mkdir(parents=True, exist_ok=True)
 
-    nssp = forecast_run.nssp
-    nssp_data = nssp.data if nssp is not None else None
-    nhsn = forecast_run.nhsn
-    nhsn_data = nhsn.data if nhsn is not None else None
-
     nssp_training_data = (
-        nssp_data.filter(pl.col("data_type") == "train")
+        forecast_run.nssp.data.filter(pl.col("data_type") == "train")
         .drop("resolution", "data_type")
         .rename({"state_abb": "geo_value"})
-        if nssp_data is not None
+        if forecast_run.nssp is not None
         else None
     )
     nhsn_training_data = (
-        nhsn_data.filter(pl.col("data_type") == "train")
+        forecast_run.nhsn.data.filter(pl.col("data_type") == "train")
         .drop("resolution", "data_type")
         .rename(
             {
@@ -95,7 +90,7 @@ def serialize_data(
                 "value": "hospital_admissions",
             }
         )
-        if nhsn_data is not None
+        if forecast_run.nhsn is not None
         else None
     )
 
@@ -113,8 +108,12 @@ def serialize_data(
             if nhsn_training_data is not None
             else None
         ),
-        "nhsn_step_size": nhsn.step_size if nhsn is not None else None,
-        "nssp_step_size": nssp.step_size if nssp is not None else None,
+        "nhsn_step_size": (
+            forecast_run.nhsn.step_size if forecast_run.nhsn is not None else None
+        ),
+        "nssp_step_size": (
+            forecast_run.nssp.step_size if forecast_run.nssp is not None else None
+        ),
         "nwss_step_size": 1,
     }
 
@@ -123,10 +122,10 @@ def serialize_data(
 
     combined_data = combine_surveillance_data(
         disease=forecast_run.disease,
-        nssp_data=nssp_data,
-        nhsn_data=nhsn_data,
+        nssp_data=(forecast_run.nssp.data if forecast_run.nssp is not None else None),
+        nhsn_data=(forecast_run.nhsn.data if forecast_run.nhsn is not None else None),
     )
-    if nssp_data is not None:
+    if forecast_run.nssp is not None:
         combined_data = append_prop_ed_data(combined_data)
 
     logger.info("Saving %s to %s", forecast_run.loc, save_dir)

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -7,7 +7,7 @@ import polars as pl
 import polars.selectors as cs
 
 from cfa.stf.routine.utils.data_utils import aggregate_ed_visits_to_epiweekly
-from cfa.stf.routine.utils.prop_utils import append_prop_data_to_combined_data
+from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
 if TYPE_CHECKING:
     from cfa.stf.routine.forecast_run import ForecastRun
@@ -143,7 +143,8 @@ def serialize_data(
     with open(Path(save_dir, "data_for_model_fit.json"), "w") as json_file:
         json.dump(data_for_model_fit, json_file, default=str)
 
-    combined_data = append_prop_data_to_combined_data(combined_data)
+    if forecast_run.nssp is not None:
+        combined_data = append_prop_ed_data(combined_data)
 
     logger.info(f"Saving {forecast_run.loc} to {save_dir}")
 

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 import polars.selectors as cs
+from cfa.stf.forecasttools import write_tabular
 
 from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
@@ -130,4 +131,4 @@ def serialize_data(
 
     logger.info(f"Saving {forecast_run.loc} to {save_dir}")
 
-    combined_data.write_csv(save_dir / "combined_data.tsv", separator="\t")
+    write_tabular(combined_data, save_dir / "combined_data.tsv")

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -7,7 +7,7 @@ import polars as pl
 import polars.selectors as cs
 
 from cfa.stf.routine.data.data_access import DataResolution
-from cfa.stf.routine.utils.data_utils import aggregate_ed_visits_to_epiweekly
+from cfa.stf.routine.utils.data_utils import aggregate_nssp_to_epiweekly
 from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
 if TYPE_CHECKING:
@@ -85,42 +85,32 @@ def serialize_data(
 
     Path(save_dir).mkdir(parents=True, exist_ok=True)
 
-    combined_data = combine_surveillance_data(
-        disease=forecast_run.disease,
-        nssp_data=forecast_run.nssp.data if forecast_run.nssp is not None else None,
-        nhsn_data=forecast_run.nhsn.data if forecast_run.nhsn is not None else None,
-    )
-    if ed_visit_input_resolution == "epiweekly":
+    nssp_data = forecast_run.nssp.data if forecast_run.nssp is not None else None
+    nhsn_data = forecast_run.nhsn.data if forecast_run.nhsn is not None else None
+    if nssp_data is not None and ed_visit_input_resolution == "epiweekly":
         logger.info("Aggregating ED visits to epiweekly resolution...")
-        combined_data = aggregate_ed_visits_to_epiweekly(combined_data)
+        nssp_data = aggregate_nssp_to_epiweekly(nssp_data)
 
-    training_data = combined_data.filter(pl.col("data_type") == "train")
-
-    nssp_training_data = None
-    if forecast_run.nssp is not None:
-        nssp_training_data = (
-            training_data.filter(
-                pl.col(".variable").is_in(["observed_ed_visits", "other_ed_visits"])
-            )
-            .pivot(on=".variable", index=["date", "geo_value"], values=".value")
-            .select(
-                "date",
-                "geo_value",
-                "observed_ed_visits",
-                "other_ed_visits",
-            )
-            .sort("date", "geo_value")
+    nssp_training_data = (
+        nssp_data.filter(pl.col("data_type") == "train")
+        .drop("resolution", "data_type")
+        .rename({"state_abb": "geo_value"})
+        if nssp_data is not None
+        else None
+    )
+    nhsn_training_data = (
+        nhsn_data.filter(pl.col("data_type") == "train")
+        .drop("resolution", "data_type")
+        .rename(
+            {
+                "date": "weekendingdate",
+                "state_abb": "jurisdiction",
+                "value": "hospital_admissions",
+            }
         )
-
-    nhsn_training_data = None
-    if forecast_run.nhsn is not None:
-        nhsn_training_data = training_data.filter(
-            pl.col(".variable") == "observed_hospital_admissions"
-        ).select(
-            pl.col("date").alias("weekendingdate"),
-            pl.col("geo_value").alias("jurisdiction"),
-            pl.col(".value").alias("hospital_admissions"),
-        )
+        if nhsn_data is not None
+        else None
+    )
 
     data_for_model_fit = {
         "loc_pop": forecast_run.loc_pop,
@@ -144,7 +134,12 @@ def serialize_data(
     with open(Path(save_dir, "data_for_model_fit.json"), "w") as json_file:
         json.dump(data_for_model_fit, json_file, default=str)
 
-    if forecast_run.nssp is not None:
+    combined_data = combine_surveillance_data(
+        disease=forecast_run.disease,
+        nssp_data=nssp_data,
+        nhsn_data=nhsn_data,
+    )
+    if nssp_data is not None:
         combined_data = append_prop_ed_data(combined_data)
 
     logger.info(f"Saving {forecast_run.loc} to {save_dir}")

--- a/src/cfa/stf/routine/epiautogp/config.py
+++ b/src/cfa/stf/routine/epiautogp/config.py
@@ -3,12 +3,14 @@
 import datetime as dt
 from dataclasses import dataclass
 
+from cfa.stf.routine.data.data_access import DataResolution
+
 
 @dataclass(frozen=True)
 class EpiAutoGPConfig:
     """Options that define how EpiAutoGP consumes a shared forecast run."""
 
     target: str
-    frequency: str
+    frequency: DataResolution
     ed_visit_type: str
     exclude_date_ranges: list[tuple[dt.date, dt.date]] | None = None

--- a/src/cfa/stf/routine/epiautogp/config.py
+++ b/src/cfa/stf/routine/epiautogp/config.py
@@ -3,14 +3,14 @@
 import datetime as dt
 from dataclasses import dataclass
 
-from cfa.stf.routine.data.data_access import DataResolution
+from cfa.stf.routine.data.data_access import DataResolution, ForecastSourceName
 
 
 @dataclass(frozen=True)
 class EpiAutoGPConfig:
     """Options that define how EpiAutoGP consumes a shared forecast run."""
 
-    target: str
+    target: ForecastSourceName
     frequency: DataResolution
     ed_visit_type: str
     exclude_date_ranges: list[tuple[dt.date, dt.date]] | None = None

--- a/src/cfa/stf/routine/epiautogp/forecast_epiautogp.py
+++ b/src/cfa/stf/routine/epiautogp/forecast_epiautogp.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import logging
 from pathlib import Path
-from typing import Literal, cast, get_args
+from typing import Literal, get_args
 
 from cfa.stf.data import get_nnh_right_truncation_pmf
 
@@ -199,7 +199,7 @@ class EpiAutoGPPipeline(ForecastPipeline):
 
     @property
     def sources(self) -> set[ForecastSourceName]:
-        return {cast(ForecastSourceName, self.config.target)}
+        return {self.config.target}
 
     @property
     def ed_visit_input_resolution(self) -> DataResolution:

--- a/src/cfa/stf/routine/epiautogp/forecast_epiautogp.py
+++ b/src/cfa/stf/routine/epiautogp/forecast_epiautogp.py
@@ -6,7 +6,7 @@ from typing import Literal, cast, get_args
 from cfa.stf.data import get_nnh_right_truncation_pmf
 
 from cfa.stf.routine._paths import EPIAUTOGP_DIR
-from cfa.stf.routine.data.data_access import ForecastSourceName
+from cfa.stf.routine.data.data_access import DataResolution, ForecastSourceName
 from cfa.stf.routine.data.hubverse_nowcast import HubverseNowcast
 from cfa.stf.routine.data.nowcast import NowcastSource
 from cfa.stf.routine.epiautogp.config import EpiAutoGPConfig
@@ -202,8 +202,8 @@ class EpiAutoGPPipeline(ForecastPipeline):
         return {cast(ForecastSourceName, self.config.target)}
 
     @property
-    def ed_visit_input_resolution(self) -> Literal["daily", "epiweekly"]:
-        return cast(Literal["daily", "epiweekly"], self.config.frequency)
+    def ed_visit_input_resolution(self) -> DataResolution:
+        return self.config.frequency
 
     def validate_configuration(self) -> None:
         _validate_epiautogp_parameters(

--- a/src/cfa/stf/routine/epiautogp/forecast_epiautogp.py
+++ b/src/cfa/stf/routine/epiautogp/forecast_epiautogp.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Literal, cast, get_args
 
 from cfa.stf.data import get_nnh_right_truncation_pmf
-from cfa.stf.forecasttools import write_tabular
 
 from cfa.stf.routine._paths import EPIAUTOGP_DIR
 from cfa.stf.routine.data.data_access import ForecastSourceName
@@ -18,7 +17,6 @@ from cfa.stf.routine.epiautogp.prep_epiautogp_data import (
 from cfa.stf.routine.epiautogp.reporting_delay_nowcast import ReportingDelayNowcast
 from cfa.stf.routine.forecast_pipeline import ForecastPipeline
 from cfa.stf.routine.forecast_run import ForecastRun
-from cfa.stf.routine.utils.data_utils import generate_epiweekly_data
 from cfa.stf.routine.utils.date_utils import parse_exclude_date_ranges
 from cfa.stf.routine.utils.language_utils import run_julia_script
 
@@ -203,19 +201,16 @@ class EpiAutoGPPipeline(ForecastPipeline):
     def sources(self) -> set[ForecastSourceName]:
         return {cast(ForecastSourceName, self.config.target)}
 
+    @property
+    def ed_visit_input_resolution(self) -> Literal["daily", "epiweekly"]:
+        return cast(Literal["daily", "epiweekly"], self.config.frequency)
+
     def validate_configuration(self) -> None:
         _validate_epiautogp_parameters(
             self.config.target,
             self.config.frequency,
             self.config.ed_visit_type,
         )
-
-    def transform_serialized_data(self, run: ForecastRun) -> None:
-        if self.config.frequency == "epiweekly":
-            self.logger.info("Generating epiweekly datasets from daily datasets...")
-            data_path = run.data_dir / "combined_data.tsv"
-            epiweekly_data = generate_epiweekly_data(data_path)
-            write_tabular(epiweekly_data, data_path)
 
     def prepare_model_artifacts(self, run: ForecastRun) -> None:
         nowcast_source = _resolve_nowcast_source(

--- a/src/cfa/stf/routine/epiautogp/prep_epiautogp_data.py
+++ b/src/cfa/stf/routine/epiautogp/prep_epiautogp_data.py
@@ -11,6 +11,7 @@ import logging
 from pathlib import Path
 
 import polars as pl
+from cfa.stf.forecasttools import read_tabular
 
 from cfa.stf.routine.data.nowcast import NowcastData, NowcastSource
 from cfa.stf.routine.epiautogp.config import EpiAutoGPConfig
@@ -299,8 +300,7 @@ def _read_tsv_data(
 
     logger.info(f"Reading {frequency} data from {tsv_path}")
 
-    # Read TSV file
-    df = pl.read_csv(tsv_path, separator="\t")
+    df = read_tabular(tsv_path)
 
     df = df.filter((pl.col("geo_value") == location) & (pl.col("disease") == disease))
 
@@ -323,8 +323,6 @@ def _read_tsv_data(
         values=".value",
     )
 
-    # Ensure date column is properly typed
-    df_pivot = df_pivot.with_columns(pl.col("date").str.to_date())
     df_pivot = df_pivot.sort("date")
 
     # Apply date exclusions if provided (before extracting to lists)

--- a/src/cfa/stf/routine/fable/forecast_fable.py
+++ b/src/cfa/stf/routine/fable/forecast_fable.py
@@ -1,10 +1,9 @@
 import datetime as dt
 import logging
 from pathlib import Path
-from typing import Literal
 
 from cfa.stf.routine._paths import FABLE_DIR
-from cfa.stf.routine.data.data_access import ForecastSourceName
+from cfa.stf.routine.data.data_access import DataResolution, ForecastSourceName
 from cfa.stf.routine.forecast_pipeline import ForecastPipeline
 from cfa.stf.routine.forecast_run import ForecastRun
 from cfa.stf.routine.utils.language_utils import run_r_script
@@ -48,7 +47,7 @@ class FablePipeline(ForecastPipeline):
         return {"nssp"}
 
     @property
-    def ed_visit_input_resolution(self) -> Literal["daily", "epiweekly"]:
+    def ed_visit_input_resolution(self) -> DataResolution:
         return "epiweekly" if self.epiweekly else "daily"
 
     def run_model(self, run: ForecastRun) -> None:

--- a/src/cfa/stf/routine/fable/forecast_fable.py
+++ b/src/cfa/stf/routine/fable/forecast_fable.py
@@ -1,14 +1,12 @@
 import datetime as dt
 import logging
 from pathlib import Path
-
-from cfa.stf.forecasttools import write_tabular
+from typing import Literal
 
 from cfa.stf.routine._paths import FABLE_DIR
 from cfa.stf.routine.data.data_access import ForecastSourceName
 from cfa.stf.routine.forecast_pipeline import ForecastPipeline
 from cfa.stf.routine.forecast_run import ForecastRun
-from cfa.stf.routine.utils.data_utils import generate_epiweekly_data
 from cfa.stf.routine.utils.language_utils import run_r_script
 
 
@@ -49,12 +47,9 @@ class FablePipeline(ForecastPipeline):
     def sources(self) -> set[ForecastSourceName]:
         return {"nssp"}
 
-    def transform_serialized_data(self, run: ForecastRun) -> None:
-        if self.epiweekly:
-            self.logger.info("Generating epiweekly datasets from daily datasets...")
-            data_path = run.data_dir / "combined_data.tsv"
-            epiweekly_data = generate_epiweekly_data(data_path)
-            write_tabular(epiweekly_data, data_path)
+    @property
+    def ed_visit_input_resolution(self) -> Literal["daily", "epiweekly"]:
+        return "epiweekly" if self.epiweekly else "daily"
 
     def run_model(self, run: ForecastRun) -> None:
         n_days_past_last_training = run.n_forecast_days + run.exclude_last_n_days

--- a/src/cfa/stf/routine/fable/forecast_fable.py
+++ b/src/cfa/stf/routine/fable/forecast_fable.py
@@ -32,15 +32,20 @@ def fable_e_other_forecasts(
 class FablePipeline(ForecastPipeline):
     """Single-location Fable E-other forecast pipeline."""
 
-    def __init__(self, *, n_samples: int, epiweekly: bool = False, **kwargs) -> None:
+    def __init__(
+        self,
+        *,
+        n_samples: int,
+        ed_visit_input_resolution: DataResolution = "daily",
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.n_samples = n_samples
-        self.epiweekly = epiweekly
+        self._ed_visit_input_resolution = ed_visit_input_resolution
 
     @property
     def model_name(self) -> str:
-        prefix = "epiweekly" if self.epiweekly else "daily"
-        return f"{prefix}_fable_e_other"
+        return f"{self.ed_visit_input_resolution}_fable_e_other"
 
     @property
     def sources(self) -> set[ForecastSourceName]:
@@ -48,7 +53,7 @@ class FablePipeline(ForecastPipeline):
 
     @property
     def ed_visit_input_resolution(self) -> DataResolution:
-        return "epiweekly" if self.epiweekly else "daily"
+        return self._ed_visit_input_resolution
 
     def run_model(self, run: ForecastRun) -> None:
         n_days_past_last_training = run.n_forecast_days + run.exclude_last_n_days
@@ -69,7 +74,7 @@ def main(
     n_samples: int,
     run_date: dt.date,
     exclude_last_n_days: int = 0,
-    epiweekly: bool = False,
+    ed_visit_input_resolution: DataResolution = "daily",
     fail_on_stale_data: bool = False,
     logger: logging.Logger | None = None,
 ) -> None:
@@ -88,6 +93,6 @@ def main(
         fail_on_stale_data=fail_on_stale_data,
         logger=logger,
         n_samples=n_samples,
-        epiweekly=epiweekly,
+        ed_visit_input_resolution=ed_visit_input_resolution,
     ).execute()
     return None

--- a/src/cfa/stf/routine/forecast_pipeline.py
+++ b/src/cfa/stf/routine/forecast_pipeline.py
@@ -107,7 +107,6 @@ class ForecastPipeline(ABC):
         self.logger.info("Processing data for %s", run.loc)
         serialize_data(
             forecast_run=run,
-            save_dir=run.data_dir,
             logger=self.logger,
             ed_visit_input_resolution=self.ed_visit_input_resolution,
         )

--- a/src/cfa/stf/routine/forecast_pipeline.py
+++ b/src/cfa/stf/routine/forecast_pipeline.py
@@ -109,7 +109,6 @@ class ForecastPipeline(ABC):
         serialize_data(
             forecast_run=run,
             logger=self.logger,
-            ed_visit_input_resolution=self.ed_visit_input_resolution,
         )
         self.prepare_model_artifacts(run)
         self.logger.info("Data preparation complete.")

--- a/src/cfa/stf/routine/forecast_pipeline.py
+++ b/src/cfa/stf/routine/forecast_pipeline.py
@@ -5,6 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Collection
 from pathlib import Path
+from typing import Literal
 
 from cfa.stf.routine.data.data_access import (
     ForecastSourceName,
@@ -13,7 +14,6 @@ from cfa.stf.routine.data.data_access import (
 from cfa.stf.routine.data.prep_data import serialize_data
 from cfa.stf.routine.forecast_run import ForecastRun
 from cfa.stf.routine.utils.date_utils import calculate_training_dates
-from cfa.stf.routine.utils.prop_utils import append_prop_data_to_combined_data
 from cfa.stf.routine.utils.r_utils import (
     make_figures_from_model_fit_dir,
     model_fit_dir_to_hub_tbl,
@@ -56,6 +56,11 @@ class ForecastPipeline(ABC):
     def sources(self) -> Collection[ForecastSourceName]:
         """Surveillance sources required by this model configuration."""
 
+    @property
+    def ed_visit_input_resolution(self) -> Literal["daily", "epiweekly"]:
+        """Resolution to use for serialized ED-visit inputs."""
+        return "daily"
+
     def validate_configuration(self) -> None:
         """Validate model-specific configuration before loading data."""
 
@@ -93,9 +98,6 @@ class ForecastPipeline(ABC):
         self.logger.info("Model run directory: %s", run.model_run_dir)
         return run
 
-    def transform_serialized_data(self, run: ForecastRun) -> None:
-        """Transform common serialized data into the model's required form."""
-
     def prepare_model_artifacts(self, run: ForecastRun) -> None:
         """Create additional files required to run the model."""
 
@@ -107,9 +109,8 @@ class ForecastPipeline(ABC):
             forecast_run=run,
             save_dir=run.data_dir,
             logger=self.logger,
+            ed_visit_input_resolution=self.ed_visit_input_resolution,
         )
-        self.transform_serialized_data(run)
-        append_prop_data_to_combined_data(run.data_dir / "combined_data.tsv")
         self.prepare_model_artifacts(run)
         self.logger.info("Data preparation complete.")
 

--- a/src/cfa/stf/routine/forecast_pipeline.py
+++ b/src/cfa/stf/routine/forecast_pipeline.py
@@ -5,9 +5,9 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Collection
 from pathlib import Path
-from typing import Literal
 
 from cfa.stf.routine.data.data_access import (
+    DataResolution,
     ForecastSourceName,
     load_surveillance_inputs,
 )
@@ -57,7 +57,7 @@ class ForecastPipeline(ABC):
         """Surveillance sources required by this model configuration."""
 
     @property
-    def ed_visit_input_resolution(self) -> Literal["daily", "epiweekly"]:
+    def ed_visit_input_resolution(self) -> DataResolution:
         """Resolution to use for serialized ED-visit inputs."""
         return "daily"
 

--- a/src/cfa/stf/routine/forecast_pipeline.py
+++ b/src/cfa/stf/routine/forecast_pipeline.py
@@ -79,6 +79,7 @@ class ForecastPipeline(ABC):
             first_training_date=first_training_date,
             last_training_date=last_training_date,
             sources=self.sources,
+            ed_visit_input_resolution=self.ed_visit_input_resolution,
             fail_on_stale_data=self.fail_on_stale_data,
             logger=self.logger,
         )

--- a/src/cfa/stf/routine/utils/data_utils.py
+++ b/src/cfa/stf/routine/utils/data_utils.py
@@ -1,10 +1,8 @@
 """Utilities for preparing forecast pipeline datasets."""
 
-from pathlib import Path
-
 import polars as pl
 import polars.selectors as cs
-from cfa.stf.forecasttools import daily_to_weekly, read_tabular
+from cfa.stf.forecasttools import daily_to_weekly
 
 
 def aggregate_long_to_epiweekly(
@@ -31,15 +29,14 @@ def aggregate_long_to_epiweekly(
     )
 
 
-def generate_epiweekly_data(data_path: Path | str) -> pl.DataFrame:
-    """Read combined data and aggregate daily ED visits to complete MMWR weeks."""
-    daily_data = read_tabular(data_path)
+def aggregate_ed_visits_to_epiweekly(data: pl.DataFrame) -> pl.DataFrame:
+    """Aggregate daily ED visits to complete MMWR weeks."""
     ed_visit_filter = pl.col(".variable").str.ends_with("_ed_visits")
-    daily_ed_data = daily_data.filter(ed_visit_filter)
-    other_data = daily_data.filter(~ed_visit_filter)
+    daily_ed_data = data.filter(ed_visit_filter)
+    other_data = data.filter(~ed_visit_filter)
 
     epiweekly_data = pl.concat(
         [aggregate_long_to_epiweekly(daily_ed_data), other_data],
         how="diagonal_relaxed",
-    ).select(daily_data.columns)
+    ).select(data.columns)
     return epiweekly_data.sort("date", ".variable")

--- a/src/cfa/stf/routine/utils/data_utils.py
+++ b/src/cfa/stf/routine/utils/data_utils.py
@@ -29,14 +29,19 @@ def aggregate_long_to_epiweekly(
     )
 
 
-def aggregate_ed_visits_to_epiweekly(data: pl.DataFrame) -> pl.DataFrame:
-    """Aggregate daily ED visits to complete MMWR weeks."""
-    ed_visit_filter = pl.col(".variable").str.ends_with("_ed_visits")
-    daily_ed_data = data.filter(ed_visit_filter)
-    other_data = data.filter(~ed_visit_filter)
-
-    epiweekly_data = pl.concat(
-        [aggregate_long_to_epiweekly(daily_ed_data), other_data],
-        how="diagonal_relaxed",
-    ).select(data.columns)
-    return epiweekly_data.sort("date", ".variable")
+def aggregate_nssp_to_epiweekly(data: pl.DataFrame) -> pl.DataFrame:
+    """Aggregate wide daily NSSP data to complete MMWR weeks."""
+    value_columns = ["observed_ed_visits", "other_ed_visits"]
+    id_columns = [column for column in data.columns if column not in value_columns]
+    long_data = data.unpivot(
+        on=value_columns,
+        index=id_columns,
+        variable_name=".variable",
+        value_name=".value",
+    )
+    return (
+        aggregate_long_to_epiweekly(long_data)
+        .pivot(on=".variable", index=id_columns, values=".value")
+        .select(data.columns)
+        .sort("date", "state_abb")
+    )

--- a/src/cfa/stf/routine/utils/prop_utils.py
+++ b/src/cfa/stf/routine/utils/prop_utils.py
@@ -109,11 +109,12 @@ def append_prop_ed_data(
     """Append disease ED visit proportion rows when both inputs are available."""
     required_vars = {observed_var, other_var}
     available_vars = set(data.get_column(".variable").unique().to_list())
-    if not required_vars <= available_vars:
-        missing_vars = ", ".join(sorted(required_vars - available_vars))
+    missing_vars = required_vars - available_vars
+    if missing_vars:
+        missing_vars_text = ", ".join(sorted(missing_vars))
         raise ValueError(
             "Cannot append ED visit proportions from incomplete NSSP data; "
-            f"missing variable(s): {missing_vars}"
+            f"missing variable(s): {missing_vars_text}"
         )
 
     return append_prop_data(

--- a/src/cfa/stf/routine/utils/prop_utils.py
+++ b/src/cfa/stf/routine/utils/prop_utils.py
@@ -101,20 +101,17 @@ def create_prop_fusion_model(
 
 
 def append_prop_data_to_combined_data(
-    data_path: Path | str,
+    data: pl.DataFrame,
     observed_var: str = "observed_ed_visits",
     other_var: str = "other_ed_visits",
     prop_var: str = "prop_disease_ed_visits",
-) -> None:
+) -> pl.DataFrame:
     """Append disease ED visit proportion rows when both inputs are available."""
-    path = Path(data_path)
-    data = read_tabular(path)
-
     required_vars = {observed_var, other_var}
     available_vars = set(data.get_column(".variable").unique().to_list())
     present_required_vars = required_vars & available_vars
     if not present_required_vars:
-        return
+        return data
     if present_required_vars != required_vars:
         missing_vars = ", ".join(sorted(required_vars - available_vars))
         raise ValueError(
@@ -122,10 +119,9 @@ def append_prop_data_to_combined_data(
             f"missing variable(s): {missing_vars}"
         )
 
-    data = append_prop_data(
+    return append_prop_data(
         data,
         observed_var=observed_var,
         other_var=other_var,
         prop_var=prop_var,
     )
-    write_tabular(data, path)

--- a/src/cfa/stf/routine/utils/prop_utils.py
+++ b/src/cfa/stf/routine/utils/prop_utils.py
@@ -100,7 +100,7 @@ def create_prop_fusion_model(
     write_tabular(prop_data, data_dir / "combined_data.tsv")
 
 
-def append_prop_data_to_combined_data(
+def append_prop_ed_data(
     data: pl.DataFrame,
     observed_var: str = "observed_ed_visits",
     other_var: str = "other_ed_visits",
@@ -109,10 +109,7 @@ def append_prop_data_to_combined_data(
     """Append disease ED visit proportion rows when both inputs are available."""
     required_vars = {observed_var, other_var}
     available_vars = set(data.get_column(".variable").unique().to_list())
-    present_required_vars = required_vars & available_vars
-    if not present_required_vars:
-        return data
-    if present_required_vars != required_vars:
+    if not required_vars <= available_vars:
         missing_vars = ", ".join(sorted(required_vars - available_vars))
         raise ValueError(
             "Cannot append ED visit proportions from incomplete NSSP data; "

--- a/tests/data/test_data_access.py
+++ b/tests/data/test_data_access.py
@@ -21,6 +21,41 @@ def _freshness(source: str) -> data_access.DataFreshness:
     )
 
 
+@pytest.mark.parametrize(
+    ("resolution", "expected_step_size"),
+    [("daily", 1), ("epiweekly", 7)],
+)
+def test_forecast_source_data_resolves_step_size(resolution, expected_step_size):
+    source = data_access.NSSPData(
+        data=pl.DataFrame({"resolution": [resolution, resolution]}),
+        freshness=_freshness("nssp"),
+        resolution=resolution,
+    )
+
+    assert source.resolution == resolution
+    assert source.step_size == expected_step_size
+
+
+def test_forecast_source_data_does_not_infer_resolution_from_data():
+    source = data_access.NSSPData(
+        data=pl.DataFrame({"unrelated_column": [1]}),
+        freshness=_freshness("nssp"),
+        resolution="daily",
+    )
+
+    assert source.resolution == "daily"
+    assert source.step_size == 1
+
+
+def test_forecast_source_data_rejects_unsupported_resolution():
+    with pytest.raises(ValueError, match="Unsupported NSSPData resolution"):
+        data_access.NSSPData(
+            data=pl.DataFrame(),
+            freshness=_freshness("nssp"),
+            resolution="monthly",
+        )
+
+
 def test_load_dataops_nssp_returns_normalized_source(monkeypatch):
     calls = {}
     source_data = pl.DataFrame(
@@ -144,6 +179,8 @@ def test_load_dataops_nhsn_returns_normalized_source(monkeypatch):
         }
     )
     assert_frame_equal(result.data, expected)
+    assert result.resolution == "epiweekly"
+    assert result.step_size == 7
     assert result.freshness.selected_version_date == dt.date(2026, 1, 8)
     assert result.freshness.latest_observed_date == dt.date(2026, 1, 10)
     assert not result.freshness.is_stale
@@ -162,6 +199,7 @@ def test_surveillance_inputs_allows_one_source(source_name):
         data_access.NSSPData(
             data=pl.DataFrame(),
             freshness=_freshness("nssp"),
+            resolution="daily",
         )
         if source_name == "nssp"
         else data_access.NHSNData(
@@ -359,6 +397,7 @@ def test_load_surveillance_inputs_uses_dataops_loaders(monkeypatch):
             }
         ),
         freshness=freshness("nssp", dt.date(2026, 1, 8)),
+        resolution="daily",
     )
     nhsn = data_access.NHSNData(
         data=pl.DataFrame(
@@ -466,8 +505,9 @@ def test_load_surveillance_inputs_stores_aggregated_nssp_data(monkeypatch):
             }
         ),
         freshness=_freshness("nssp"),
+        resolution="daily",
     )
-    prepared_nssp_data = nssp.data.clone()
+    prepared_nssp_data = nssp.data.with_columns(resolution=pl.lit("epiweekly"))
 
     def aggregate(data):
         assert data is nssp.data
@@ -492,6 +532,8 @@ def test_load_surveillance_inputs_stores_aggregated_nssp_data(monkeypatch):
     )
 
     assert surveillance.nssp.data is prepared_nssp_data
+    assert surveillance.nssp.resolution == "epiweekly"
+    assert surveillance.nssp.step_size == 7
     assert surveillance.nssp.freshness is nssp.freshness
     assert surveillance.nssp is not nssp
 
@@ -513,6 +555,7 @@ def test_load_surveillance_inputs_only_loads_requested_source(
             }
         ),
         freshness=_freshness("nssp"),
+        resolution="daily",
     )
     nhsn = data_access.NHSNData(
         data=pl.DataFrame(

--- a/tests/data/test_data_access.py
+++ b/tests/data/test_data_access.py
@@ -36,17 +36,6 @@ def test_forecast_source_data_resolves_step_size(resolution, expected_step_size)
     assert source.step_size == expected_step_size
 
 
-def test_forecast_source_data_does_not_infer_resolution_from_data():
-    source = data_access.NSSPData(
-        data=pl.DataFrame({"unrelated_column": [1]}),
-        freshness=_freshness("nssp"),
-        resolution="daily",
-    )
-
-    assert source.resolution == "daily"
-    assert source.step_size == 1
-
-
 def test_forecast_source_data_rejects_unsupported_resolution():
     with pytest.raises(ValueError, match="Unsupported NSSPData resolution"):
         data_access.NSSPData(

--- a/tests/data/test_data_access.py
+++ b/tests/data/test_data_access.py
@@ -453,6 +453,49 @@ def test_load_surveillance_inputs_uses_dataops_loaders(monkeypatch):
     }
 
 
+def test_load_surveillance_inputs_stores_aggregated_nssp_data(monkeypatch):
+    nssp = data_access.NSSPData(
+        data=pl.DataFrame(
+            {
+                "date": [dt.date(2026, 1, 8)],
+                "state_abb": ["CA"],
+                "observed_ed_visits": [10],
+                "other_ed_visits": [90],
+                "data_type": ["eval"],
+                "resolution": ["daily"],
+            }
+        ),
+        freshness=_freshness("nssp"),
+    )
+    prepared_nssp_data = nssp.data.clone()
+
+    def aggregate(data):
+        assert data is nssp.data
+        return prepared_nssp_data
+
+    monkeypatch.setattr(data_access, "_load_dataops_nssp", lambda **kwargs: nssp)
+    monkeypatch.setattr(data_access, "aggregate_nssp_to_epiweekly", aggregate)
+    monkeypatch.setattr(
+        data_access,
+        "get_us_loc_pop_tbl",
+        lambda: pl.DataFrame({"abbr": ["CA"], "population": [39_000_000]}),
+    )
+
+    surveillance = data_access.load_surveillance_inputs(
+        disease="covid",
+        loc_abb="CA",
+        run_date=dt.date(2026, 1, 8),
+        first_training_date=dt.date(2025, 12, 1),
+        last_training_date=dt.date(2026, 1, 7),
+        sources={"nssp"},
+        ed_visit_input_resolution="epiweekly",
+    )
+
+    assert surveillance.nssp.data is prepared_nssp_data
+    assert surveillance.nssp.freshness is nssp.freshness
+    assert surveillance.nssp is not nssp
+
+
 @pytest.mark.parametrize("requested_source", ["nssp", "nhsn"])
 def test_load_surveillance_inputs_only_loads_requested_source(
     monkeypatch,

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -8,6 +8,7 @@ from tests.factories import make_test_forecast_run
 
 from cfa.stf.routine.data import prep_data
 from cfa.stf.routine.data.prep_data import serialize_data
+from cfa.stf.routine.utils.data_utils import aggregate_nssp_to_epiweekly
 
 
 @pytest.mark.parametrize(
@@ -81,7 +82,7 @@ def test_serialize_data_handles_present_sources(
     assert set(combined_data.get_column(".variable")) == expected_variables
 
 
-def test_serialize_data_uses_aggregated_ed_visits_for_both_artifacts(tmp_path):
+def test_serialize_data_uses_run_ed_visits_for_both_artifacts(tmp_path):
     forecast_run = make_test_forecast_run(
         output_dir=tmp_path,
         sources=("nssp",),
@@ -97,6 +98,7 @@ def test_serialize_data_uses_aggregated_ed_visits_for_both_artifacts(tmp_path):
             "resolution": ["daily"] * 14,
         }
     )
+    nssp_data = aggregate_nssp_to_epiweekly(nssp_data)
     surveillance = replace(
         forecast_run.surveillance,
         nssp=replace(forecast_run.nssp, data=nssp_data),

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 
 import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 from tests.factories import make_test_forecast_run
 
 from cfa.stf.routine.data import prep_data
@@ -136,11 +137,17 @@ def test_serialize_data_uses_run_ed_visits_for_both_artifacts(tmp_path):
             ]
         )
     ).select("date", "data_type", ".variable", ".value")
-    assert weekly_ed_data.rows() == [
-        (dt.date(2025, 1, 11), "train", "observed_ed_visits", 28.0),
-        (dt.date(2025, 1, 11), "train", "other_ed_visits", 63.0),
-        (dt.date(2025, 1, 11), "train", "prop_disease_ed_visits", 28 / 91),
-        (dt.date(2025, 1, 18), "eval", "observed_ed_visits", 77.0),
-        (dt.date(2025, 1, 18), "eval", "other_ed_visits", 63.0),
-        (dt.date(2025, 1, 18), "eval", "prop_disease_ed_visits", 77 / 140),
-    ]
+    expected = pl.DataFrame(
+        {
+            "date": [dt.date(2025, 1, 11)] * 3 + [dt.date(2025, 1, 18)] * 3,
+            "data_type": ["train"] * 3 + ["eval"] * 3,
+            ".variable": [
+                "observed_ed_visits",
+                "other_ed_visits",
+                "prop_disease_ed_visits",
+            ]
+            * 2,
+            ".value": [28.0, 63.0, 28 / 91, 77.0, 63.0, 77 / 140],
+        }
+    )
+    assert_frame_equal(weekly_ed_data, expected)

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -54,12 +54,9 @@ def test_serialize_data_handles_present_sources(
         sources=sources,
     )
 
-    serialize_data(
-        forecast_run=forecast_run,
-        save_dir=tmp_path,
-    )
+    serialize_data(forecast_run=forecast_run)
 
-    with open(tmp_path / "data_for_model_fit.json") as file:
+    with open(forecast_run.data_dir / "data_for_model_fit.json") as file:
         model_data = json.load(file)
     assert (model_data["nssp_training_data"] is not None) == ("nssp" in sources)
     assert (model_data["nhsn_training_data"] is not None) == ("nhsn" in sources)
@@ -78,7 +75,9 @@ def test_serialize_data_handles_present_sources(
             "hospital_admissions",
         }
 
-    combined_data = pl.read_csv(tmp_path / "combined_data.tsv", separator="\t")
+    combined_data = pl.read_csv(
+        forecast_run.data_dir / "combined_data.tsv", separator="\t"
+    )
     assert set(combined_data.get_column(".variable")) == expected_variables
 
 
@@ -106,11 +105,10 @@ def test_serialize_data_uses_aggregated_ed_visits_for_both_artifacts(tmp_path):
 
     serialize_data(
         forecast_run=forecast_run,
-        save_dir=tmp_path,
         ed_visit_input_resolution="epiweekly",
     )
 
-    with open(tmp_path / "data_for_model_fit.json") as file:
+    with open(forecast_run.data_dir / "data_for_model_fit.json") as file:
         model_data = json.load(file)
     assert model_data["nssp_step_size"] == 7
     assert model_data["nssp_training_data"] == {
@@ -121,7 +119,7 @@ def test_serialize_data_uses_aggregated_ed_visits_for_both_artifacts(tmp_path):
     }
 
     combined_data = pl.read_csv(
-        tmp_path / "combined_data.tsv",
+        forecast_run.data_dir / "combined_data.tsv",
         separator="\t",
         try_parse_dates=True,
     )

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 
 import polars as pl
 import pytest
+from cfa.stf.forecasttools import read_tabular
 from polars.testing import assert_frame_equal
 from tests.factories import make_test_forecast_run
 
@@ -78,9 +79,7 @@ def test_serialize_data_handles_present_sources(
             "hospital_admissions",
         }
 
-    combined_data = pl.read_csv(
-        forecast_run.data_dir / "combined_data.tsv", separator="\t"
-    )
+    combined_data = read_tabular(forecast_run.data_dir / "combined_data.tsv")
     assert set(combined_data.get_column(".variable")) == expected_variables
 
 
@@ -123,11 +122,7 @@ def test_serialize_data_uses_run_ed_visits_for_both_artifacts(tmp_path):
         "other_ed_visits": [63],
     }
 
-    combined_data = pl.read_csv(
-        forecast_run.data_dir / "combined_data.tsv",
-        separator="\t",
-        try_parse_dates=True,
-    )
+    combined_data = read_tabular(forecast_run.data_dir / "combined_data.tsv")
     weekly_ed_data = combined_data.filter(
         pl.col(".variable").is_in(
             [

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -1,4 +1,6 @@
+import datetime as dt
 import json
+from dataclasses import replace
 
 import polars as pl
 import pytest
@@ -6,7 +8,6 @@ from tests.factories import make_test_forecast_run
 
 from cfa.stf.routine.data import prep_data
 from cfa.stf.routine.data.prep_data import serialize_data
-from cfa.stf.routine.utils.prop_utils import append_prop_data_to_combined_data
 
 
 @pytest.mark.parametrize(
@@ -57,12 +58,12 @@ def test_serialize_data_handles_present_sources(
         forecast_run=forecast_run,
         save_dir=tmp_path,
     )
-    append_prop_data_to_combined_data(tmp_path / "combined_data.tsv")
 
     with open(tmp_path / "data_for_model_fit.json") as file:
         model_data = json.load(file)
     assert (model_data["nssp_training_data"] is not None) == ("nssp" in sources)
     assert (model_data["nhsn_training_data"] is not None) == ("nhsn" in sources)
+    assert model_data["nssp_step_size"] == 1
     if "nssp" in sources:
         assert set(model_data["nssp_training_data"]) == {
             "date",
@@ -79,3 +80,65 @@ def test_serialize_data_handles_present_sources(
 
     combined_data = pl.read_csv(tmp_path / "combined_data.tsv", separator="\t")
     assert set(combined_data.get_column(".variable")) == expected_variables
+
+
+def test_serialize_data_uses_aggregated_ed_visits_for_both_artifacts(tmp_path):
+    forecast_run = make_test_forecast_run(
+        output_dir=tmp_path,
+        sources=("nssp",),
+    )
+    dates = pl.date_range(dt.date(2025, 1, 5), dt.date(2025, 1, 18), eager=True)
+    nssp_data = pl.DataFrame(
+        {
+            "date": dates,
+            "state_abb": ["CA"] * 14,
+            "observed_ed_visits": list(range(1, 15)),
+            "other_ed_visits": [9] * 14,
+            "data_type": ["train"] * 7 + ["eval"] * 7,
+            "resolution": ["daily"] * 14,
+        }
+    )
+    surveillance = replace(
+        forecast_run.surveillance,
+        nssp=replace(forecast_run.nssp, data=nssp_data),
+    )
+    forecast_run = replace(forecast_run, surveillance=surveillance)
+
+    serialize_data(
+        forecast_run=forecast_run,
+        save_dir=tmp_path,
+        ed_visit_input_resolution="epiweekly",
+    )
+
+    with open(tmp_path / "data_for_model_fit.json") as file:
+        model_data = json.load(file)
+    assert model_data["nssp_step_size"] == 7
+    assert model_data["nssp_training_data"] == {
+        "date": ["2025-01-11"],
+        "geo_value": ["CA"],
+        "observed_ed_visits": [28],
+        "other_ed_visits": [63],
+    }
+
+    combined_data = pl.read_csv(
+        tmp_path / "combined_data.tsv",
+        separator="\t",
+        try_parse_dates=True,
+    )
+    weekly_ed_data = combined_data.filter(
+        pl.col(".variable").is_in(
+            [
+                "observed_ed_visits",
+                "other_ed_visits",
+                "prop_disease_ed_visits",
+            ]
+        )
+    ).select("date", "data_type", ".variable", ".value")
+    assert weekly_ed_data.rows() == [
+        (dt.date(2025, 1, 11), "train", "observed_ed_visits", 28.0),
+        (dt.date(2025, 1, 11), "train", "other_ed_visits", 63.0),
+        (dt.date(2025, 1, 11), "train", "prop_disease_ed_visits", 28 / 91),
+        (dt.date(2025, 1, 18), "eval", "observed_ed_visits", 77.0),
+        (dt.date(2025, 1, 18), "eval", "other_ed_visits", 63.0),
+        (dt.date(2025, 1, 18), "eval", "prop_disease_ed_visits", 77 / 140),
+    ]

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -61,7 +61,8 @@ def test_serialize_data_handles_present_sources(
         model_data = json.load(file)
     assert (model_data["nssp_training_data"] is not None) == ("nssp" in sources)
     assert (model_data["nhsn_training_data"] is not None) == ("nhsn" in sources)
-    assert model_data["nssp_step_size"] == 1
+    assert model_data["nssp_step_size"] == (1 if "nssp" in sources else None)
+    assert model_data["nhsn_step_size"] == (7 if "nhsn" in sources else None)
     if "nssp" in sources:
         assert set(model_data["nssp_training_data"]) == {
             "date",

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -101,14 +101,15 @@ def test_serialize_data_uses_run_ed_visits_for_both_artifacts(tmp_path):
     nssp_data = aggregate_nssp_to_epiweekly(nssp_data)
     surveillance = replace(
         forecast_run.surveillance,
-        nssp=replace(forecast_run.nssp, data=nssp_data),
+        nssp=replace(
+            forecast_run.nssp,
+            data=nssp_data,
+            resolution="epiweekly",
+        ),
     )
     forecast_run = replace(forecast_run, surveillance=surveillance)
 
-    serialize_data(
-        forecast_run=forecast_run,
-        ed_visit_input_resolution="epiweekly",
-    )
+    serialize_data(forecast_run=forecast_run)
 
     with open(forecast_run.data_dir / "data_for_model_fit.json") as file:
         model_data = json.load(file)

--- a/tests/epiautogp/test_forecast_utils.py
+++ b/tests/epiautogp/test_forecast_utils.py
@@ -60,6 +60,7 @@ def test_pipeline_declares_model_name_and_source(
 
     assert pipeline.model_name == expected
     assert pipeline.sources == {target}
+    assert pipeline.ed_visit_input_resolution == frequency
 
 
 def test_pipeline_validates_configuration_before_loading(tmp_path):
@@ -89,21 +90,6 @@ def test_prepare_model_artifacts_resolves_nowcast_without_mutating_state(
         ReportingDelayNowcast,
     )
     assert not hasattr(pipeline, "nowcast_source")
-
-
-@patch("cfa.stf.routine.epiautogp.forecast_epiautogp.write_tabular")
-@patch("cfa.stf.routine.epiautogp.forecast_epiautogp.generate_epiweekly_data")
-def test_epiweekly_pipeline_aggregates_common_inputs(
-    mock_generate, mock_write, tmp_path
-):
-    pipeline = _pipeline(tmp_path, frequency="epiweekly")
-    run = _run(tmp_path)
-
-    pipeline.transform_serialized_data(run)
-
-    data_path = run.data_dir / "combined_data.tsv"
-    mock_generate.assert_called_once_with(data_path)
-    mock_write.assert_called_once_with(mock_generate.return_value, data_path)
 
 
 @patch("cfa.stf.routine.epiautogp.forecast_epiautogp.run_epiautogp_forecast")

--- a/tests/epiautogp/test_prep_epiautogp_data.py
+++ b/tests/epiautogp/test_prep_epiautogp_data.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 import polars as pl
 import pytest
+from cfa.stf.forecasttools import write_tabular
 from tests.factories import make_test_forecast_run
 
 from cfa.stf.routine.data.nowcast import NowcastData
@@ -293,7 +294,7 @@ class FakeNowcastSource:
 
 
 def _write_combined_data(path):
-    pl.DataFrame(
+    combined_data = pl.DataFrame(
         [
             {
                 "date": dt.date(2024, 1, 1),
@@ -320,7 +321,8 @@ def _write_combined_data(path):
                 ".value": 999.0,
             },
         ]
-    ).write_csv(path, separator="\t")
+    )
+    write_tabular(combined_data, path)
 
 
 def _epiautogp_run(tmp_path):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -62,6 +62,7 @@ def make_test_surveillance_inputs(
         NSSPData(
             data=nssp_data,
             freshness=freshness("nssp"),
+            resolution="daily",
         )
         if "nssp" in requested_sources
         else None

--- a/tests/integration/model_test_utils.py
+++ b/tests/integration/model_test_utils.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from math import isclose
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from cfa.stf.routine.epiautogp import forecast_epiautogp as epiautogp_module
 from cfa.stf.routine.fable import forecast_fable as fable_module
 from cfa.stf.routine.pyrenew_hew import forecast_pyrenew as pyrenew_module
 from cfa.stf.routine.pyrenew_hew import model_inputs as pyrenew_inputs_module
+from cfa.stf.routine.utils.data_utils import aggregate_nssp_to_epiweekly
 
 FORECAST_DIR_NAME = f"{REPORT_DATE.isoformat()}_forecasts"
 N_TRAINING_DAYS = 42
@@ -63,15 +65,25 @@ def patch_dataops_with_mock_data(monkeypatch) -> None:
         first_training_date,
         last_training_date,
         sources,
+        ed_visit_input_resolution="daily",
         **kwargs,
     ):
-        return make_surveillance_inputs(
+        surveillance = make_surveillance_inputs(
             location=loc_abb,
             disease=disease,
             sources=sources,
             first_training_date=first_training_date,
             last_training_date=last_training_date,
         )
+        if surveillance.nssp is not None and ed_visit_input_resolution == "epiweekly":
+            surveillance = replace(
+                surveillance,
+                nssp=replace(
+                    surveillance.nssp,
+                    data=aggregate_nssp_to_epiweekly(surveillance.nssp.data),
+                ),
+            )
+        return surveillance
 
     monkeypatch.setattr(
         forecast_pipeline_module,

--- a/tests/integration/model_test_utils.py
+++ b/tests/integration/model_test_utils.py
@@ -81,6 +81,7 @@ def patch_dataops_with_mock_data(monkeypatch) -> None:
                 nssp=replace(
                     surveillance.nssp,
                     data=aggregate_nssp_to_epiweekly(surveillance.nssp.data),
+                    resolution="epiweekly",
                 ),
             )
         return surveillance

--- a/tests/integration/model_test_utils.py
+++ b/tests/integration/model_test_utils.py
@@ -5,6 +5,7 @@ from pyrenew_multisignal.hew.utils import flags_from_hew_letters
 
 from cfa.stf.routine import forecast_pipeline as forecast_pipeline_module
 from cfa.stf.routine._paths import PRODUCTION_PRIORS
+from cfa.stf.routine.data.data_access import DataResolution
 from cfa.stf.routine.data.generate_test_data import (
     REPORT_DATE,
     REPORTING_DELAY_PMF,
@@ -108,7 +109,11 @@ def configure_data_mode(request, monkeypatch) -> str:
 
 
 def run_fable(
-    workspace: Path, disease: str, location: str, *, epiweekly: bool = False
+    workspace: Path,
+    disease: str,
+    location: str,
+    *,
+    ed_visit_input_resolution: DataResolution = "daily",
 ) -> None:
     fable_module.main(
         disease=disease,
@@ -119,7 +124,7 @@ def run_fable(
         exclude_last_n_days=EXCLUDE_LAST_N_DAYS,
         n_samples=40,
         run_date=REPORT_DATE,
-        epiweekly=epiweekly,
+        ed_visit_input_resolution=ed_visit_input_resolution,
     )
 
 

--- a/tests/integration/test_fable_forecast.py
+++ b/tests/integration/test_fable_forecast.py
@@ -13,7 +13,12 @@ def test_fable_forecast(pipeline_workspace, monkeypatch, request):
     configure_data_mode(request, monkeypatch)
 
     run_fable(pipeline_workspace, disease, location)
-    run_fable(pipeline_workspace, disease, location, epiweekly=True)
+    run_fable(
+        pipeline_workspace,
+        disease,
+        location,
+        ed_visit_input_resolution="epiweekly",
+    )
 
     assert_model_outputs(
         pipeline_workspace,

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -106,7 +106,12 @@ def test_reduced_pipeline_end_to_end(pipeline_workspace, monkeypatch, request):
                 run_fable(workspace, disease, location)
 
             with _status_step(f"Running epiweekly Fable for {disease}, {location}"):
-                run_fable(workspace, disease, location, epiweekly=True)
+                run_fable(
+                    workspace,
+                    disease,
+                    location,
+                    ed_visit_input_resolution="epiweekly",
+                )
 
             with _status_step(f"Running PyRenew for {disease}, {location}"):
                 run_pyrenew(workspace, disease, location)

--- a/tests/test_forecast_entrypoints.py
+++ b/tests/test_forecast_entrypoints.py
@@ -74,7 +74,7 @@ from cfa.stf.routine.pyrenew_hew import forecast_pyrenew
                 "n_samples": 15,
                 "run_date": dt.date(2026, 1, 7),
                 "exclude_last_n_days": 3,
-                "epiweekly": True,
+                "ed_visit_input_resolution": "epiweekly",
                 "fail_on_stale_data": True,
             },
             {
@@ -87,7 +87,7 @@ from cfa.stf.routine.pyrenew_hew import forecast_pyrenew
                 "exclude_last_n_days": 3,
                 "fail_on_stale_data": True,
                 "n_samples": 15,
-                "epiweekly": True,
+                "ed_visit_input_resolution": "epiweekly",
             },
             id="fable",
         ),

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -127,7 +127,6 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
     pipeline = _pipeline(
         tmp_path,
         events=events,
-        ed_visit_input_resolution="epiweekly",
     )
     run = make_test_forecast_run(
         output_dir=tmp_path,

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -26,9 +26,6 @@ class TestPipeline(ForecastPipeline):
     def validate_configuration(self):
         self.events.append("validate")
 
-    def transform_serialized_data(self, run):
-        self.events.append("transform")
-
     def prepare_model_artifacts(self, run):
         self.events.append("prepare_artifacts")
 
@@ -121,16 +118,13 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
         "build_forecast_run",
         lambda: events.append("build_run") or run,
     )
-    monkeypatch.setattr(
-        pipeline_module,
-        "serialize_data",
-        lambda **kwargs: events.append("serialize"),
-    )
-    monkeypatch.setattr(
-        pipeline_module,
-        "append_prop_data_to_combined_data",
-        lambda *args: events.append("append_prop"),
-    )
+    serialize_kwargs = {}
+
+    def serialize(**kwargs):
+        serialize_kwargs.update(kwargs)
+        events.append("serialize")
+
+    monkeypatch.setattr(pipeline_module, "serialize_data", serialize)
     monkeypatch.setattr(
         pipeline_module,
         "make_figures_from_model_fit_dir",
@@ -149,13 +143,12 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
         "validate",
         "build_run",
         "serialize",
-        "transform",
-        "append_prop",
         "prepare_artifacts",
         "run_model",
         "figures",
         "hubverse",
     ]
+    assert serialize_kwargs["ed_visit_input_resolution"] == "daily"
     assert run.data_dir.is_dir()
     messages = [record.getMessage() for record in caplog.records]
     assert messages[0] == (

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -11,9 +11,10 @@ from tests.factories import make_test_forecast_run, make_test_surveillance_input
 class TestPipeline(ForecastPipeline):
     __test__ = False
 
-    def __init__(self, *, events=None, **kwargs):
+    def __init__(self, *, events=None, ed_visit_input_resolution="daily", **kwargs):
         super().__init__(**kwargs)
         self.events = events if events is not None else []
+        self._ed_visit_input_resolution = ed_visit_input_resolution
 
     @property
     def model_name(self):
@@ -22,6 +23,10 @@ class TestPipeline(ForecastPipeline):
     @property
     def sources(self):
         return {"nssp"}
+
+    @property
+    def ed_visit_input_resolution(self):
+        return self._ed_visit_input_resolution
 
     def validate_configuration(self):
         self.events.append("validate")
@@ -33,7 +38,13 @@ class TestPipeline(ForecastPipeline):
         self.events.append("run_model")
 
 
-def _pipeline(tmp_path, *, events=None, fail_on_stale_data=False):
+def _pipeline(
+    tmp_path,
+    *,
+    events=None,
+    fail_on_stale_data=False,
+    ed_visit_input_resolution="daily",
+):
     return TestPipeline(
         disease="covid",
         loc="CA",
@@ -45,6 +56,7 @@ def _pipeline(tmp_path, *, events=None, fail_on_stale_data=False):
         fail_on_stale_data=fail_on_stale_data,
         logger=logging.getLogger("test-forecast-pipeline"),
         events=events,
+        ed_visit_input_resolution=ed_visit_input_resolution,
     )
 
 
@@ -91,6 +103,7 @@ def test_build_forecast_run_loads_inputs_and_constructs_canonical_state(
         1,
     )
     assert calls["load"]["sources"] == {"nssp"}
+    assert calls["load"]["ed_visit_input_resolution"] == "daily"
     assert calls["load"]["fail_on_stale_data"] is True
     assert run.model_batch_dir == (
         tmp_path / "covid_r_2024-12-20_f_2024-09-20_t_2024-12-18"
@@ -157,6 +170,34 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
         "Starting single-location pipeline for model test_model, location CA, "
         "and run date 2024-12-20."
     )
+
+
+def test_build_forecast_run_requests_ed_visit_input_resolution(monkeypatch, tmp_path):
+    from cfa.stf.routine import forecast_pipeline as pipeline_module
+
+    pipeline = _pipeline(tmp_path, ed_visit_input_resolution="epiweekly")
+    surveillance = make_test_surveillance_inputs(sources={"nssp"})
+    calls = {}
+
+    def load(**kwargs):
+        calls.update(kwargs)
+        return surveillance
+
+    monkeypatch.setattr(
+        pipeline_module,
+        "calculate_training_dates",
+        lambda *args: (dt.date(2024, 9, 20), dt.date(2024, 12, 19)),
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "load_surveillance_inputs",
+        load,
+    )
+
+    run = pipeline.build_forecast_run()
+
+    assert calls["ed_visit_input_resolution"] == "epiweekly"
+    assert run.surveillance is surveillance
 
 
 @pytest.mark.parametrize(

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -141,8 +141,12 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
     )
     serialize_kwargs = {}
 
-    def serialize(**kwargs):
-        serialize_kwargs.update(kwargs)
+    def serialize(*, forecast_run, logger, ed_visit_input_resolution):
+        serialize_kwargs.update(
+            forecast_run=forecast_run,
+            logger=logger,
+            ed_visit_input_resolution=ed_visit_input_resolution,
+        )
         events.append("serialize")
 
     monkeypatch.setattr(pipeline_module, "serialize_data", serialize)
@@ -170,7 +174,6 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
         "hubverse",
     ]
     assert serialize_kwargs["forecast_run"] is run
-    assert "save_dir" not in serialize_kwargs
     assert serialize_kwargs["ed_visit_input_resolution"] == "epiweekly"
     assert run.data_dir.is_dir()
     messages = [record.getMessage() for record in caplog.records]

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -82,7 +82,11 @@ def test_build_forecast_run_loads_inputs_and_constructs_canonical_state(
     monkeypatch.setattr(pipeline_module, "calculate_training_dates", calculate)
     monkeypatch.setattr(pipeline_module, "load_surveillance_inputs", load)
 
-    pipeline = _pipeline(tmp_path, fail_on_stale_data=True)
+    pipeline = _pipeline(
+        tmp_path,
+        fail_on_stale_data=True,
+        ed_visit_input_resolution="epiweekly",
+    )
     run = pipeline.build_forecast_run()
 
     assert run == ForecastRun(
@@ -103,7 +107,7 @@ def test_build_forecast_run_loads_inputs_and_constructs_canonical_state(
         1,
     )
     assert calls["load"]["sources"] == {"nssp"}
-    assert calls["load"]["ed_visit_input_resolution"] == "daily"
+    assert calls["load"]["ed_visit_input_resolution"] == "epiweekly"
     assert calls["load"]["fail_on_stale_data"] is True
     assert run.model_batch_dir == (
         tmp_path / "covid_r_2024-12-20_f_2024-09-20_t_2024-12-18"
@@ -120,7 +124,11 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
     from cfa.stf.routine import forecast_pipeline as pipeline_module
 
     events = []
-    pipeline = _pipeline(tmp_path, events=events)
+    pipeline = _pipeline(
+        tmp_path,
+        events=events,
+        ed_visit_input_resolution="epiweekly",
+    )
     run = make_test_forecast_run(
         output_dir=tmp_path,
         sources={"nssp"},
@@ -163,41 +171,13 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
     ]
     assert serialize_kwargs["forecast_run"] is run
     assert "save_dir" not in serialize_kwargs
-    assert serialize_kwargs["ed_visit_input_resolution"] == "daily"
+    assert serialize_kwargs["ed_visit_input_resolution"] == "epiweekly"
     assert run.data_dir.is_dir()
     messages = [record.getMessage() for record in caplog.records]
     assert messages[0] == (
         "Starting single-location pipeline for model test_model, location CA, "
         "and run date 2024-12-20."
     )
-
-
-def test_build_forecast_run_requests_ed_visit_input_resolution(monkeypatch, tmp_path):
-    from cfa.stf.routine import forecast_pipeline as pipeline_module
-
-    pipeline = _pipeline(tmp_path, ed_visit_input_resolution="epiweekly")
-    surveillance = make_test_surveillance_inputs(sources={"nssp"})
-    calls = {}
-
-    def load(**kwargs):
-        calls.update(kwargs)
-        return surveillance
-
-    monkeypatch.setattr(
-        pipeline_module,
-        "calculate_training_dates",
-        lambda *args: (dt.date(2024, 9, 20), dt.date(2024, 12, 19)),
-    )
-    monkeypatch.setattr(
-        pipeline_module,
-        "load_surveillance_inputs",
-        load,
-    )
-
-    run = pipeline.build_forecast_run()
-
-    assert calls["ed_visit_input_resolution"] == "epiweekly"
-    assert run.surveillance is surveillance
 
 
 @pytest.mark.parametrize(

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -148,6 +148,8 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
         "figures",
         "hubverse",
     ]
+    assert serialize_kwargs["forecast_run"] is run
+    assert "save_dir" not in serialize_kwargs
     assert serialize_kwargs["ed_visit_input_resolution"] == "daily"
     assert run.data_dir.is_dir()
     messages = [record.getMessage() for record in caplog.records]

--- a/tests/test_forecast_pipeline.py
+++ b/tests/test_forecast_pipeline.py
@@ -141,11 +141,10 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
     )
     serialize_kwargs = {}
 
-    def serialize(*, forecast_run, logger, ed_visit_input_resolution):
+    def serialize(*, forecast_run, logger):
         serialize_kwargs.update(
             forecast_run=forecast_run,
             logger=logger,
-            ed_visit_input_resolution=ed_visit_input_resolution,
         )
         events.append("serialize")
 
@@ -174,7 +173,6 @@ def test_execute_runs_lifecycle_in_order(monkeypatch, tmp_path, caplog):
         "hubverse",
     ]
     assert serialize_kwargs["forecast_run"] is run
-    assert serialize_kwargs["ed_visit_input_resolution"] == "epiweekly"
     assert run.data_dir.is_dir()
     messages = [record.getMessage() for record in caplog.records]
     assert messages[0] == (

--- a/tests/test_model_pipelines.py
+++ b/tests/test_model_pipelines.py
@@ -30,18 +30,17 @@ def _common_kwargs(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("epiweekly", "expected"),
-    [(False, "daily"), (True, "epiweekly")],
+    "resolution",
+    ["daily", "epiweekly"],
 )
-def test_fable_pipeline_declares_ed_visit_input_resolution(
-    tmp_path, epiweekly, expected
-):
+def test_fable_pipeline_declares_ed_visit_input_resolution(tmp_path, resolution):
     pipeline = FablePipeline(
         **_common_kwargs(tmp_path),
         n_samples=10,
-        epiweekly=epiweekly,
+        ed_visit_input_resolution=resolution,
     )
-    assert pipeline.ed_visit_input_resolution == expected
+    assert pipeline.ed_visit_input_resolution == resolution
+    assert pipeline.model_name == f"{resolution}_fable_e_other"
 
 
 @patch("cfa.stf.routine.fable.forecast_fable.fable_e_other_forecasts")

--- a/tests/test_model_pipelines.py
+++ b/tests/test_model_pipelines.py
@@ -29,21 +29,19 @@ def _common_kwargs(tmp_path):
     }
 
 
-@patch("cfa.stf.routine.fable.forecast_fable.write_tabular")
-@patch("cfa.stf.routine.fable.forecast_fable.generate_epiweekly_data")
-def test_fable_pipeline_aggregates_weekly_inputs(mock_generate, mock_write, tmp_path):
+@pytest.mark.parametrize(
+    ("epiweekly", "expected"),
+    [(False, "daily"), (True, "epiweekly")],
+)
+def test_fable_pipeline_declares_ed_visit_input_resolution(
+    tmp_path, epiweekly, expected
+):
     pipeline = FablePipeline(
         **_common_kwargs(tmp_path),
         n_samples=10,
-        epiweekly=True,
+        epiweekly=epiweekly,
     )
-    run = _run(tmp_path, model_name=pipeline.model_name)
-
-    pipeline.transform_serialized_data(run)
-
-    data_path = run.data_dir / "combined_data.tsv"
-    mock_generate.assert_called_once_with(data_path)
-    mock_write.assert_called_once_with(mock_generate.return_value, data_path)
+    assert pipeline.ed_visit_input_resolution == expected
 
 
 @patch("cfa.stf.routine.fable.forecast_fable.fable_e_other_forecasts")
@@ -94,6 +92,10 @@ def _pyrenew_pipeline(tmp_path, **overrides):
 def test_pyrenew_pipeline_preserves_signal_validation(tmp_path, overrides, message):
     with pytest.raises(ValueError, match=message):
         _pyrenew_pipeline(tmp_path, **overrides).validate_configuration()
+
+
+def test_pyrenew_pipeline_uses_daily_ed_visit_inputs(tmp_path):
+    assert _pyrenew_pipeline(tmp_path).ed_visit_input_resolution == "daily"
 
 
 @patch("cfa.stf.routine.pyrenew_hew.forecast_pyrenew.serialize_pyrenew_model_params")

--- a/tests/test_model_pipelines.py
+++ b/tests/test_model_pipelines.py
@@ -93,10 +93,6 @@ def test_pyrenew_pipeline_preserves_signal_validation(tmp_path, overrides, messa
         _pyrenew_pipeline(tmp_path, **overrides).validate_configuration()
 
 
-def test_pyrenew_pipeline_uses_daily_ed_visit_inputs(tmp_path):
-    assert _pyrenew_pipeline(tmp_path).ed_visit_input_resolution == "daily"
-
-
 @patch("cfa.stf.routine.pyrenew_hew.forecast_pyrenew.serialize_pyrenew_model_params")
 @patch("cfa.stf.routine.pyrenew_hew.forecast_pyrenew.copy_priors")
 @patch("cfa.stf.routine.pyrenew_hew.forecast_pyrenew.resolve_pyrenew_model_inputs")

--- a/tests/utils/test_common_utils.py
+++ b/tests/utils/test_common_utils.py
@@ -4,9 +4,7 @@ import datetime as dt
 import logging
 import sys
 
-import polars as pl
 import pytest
-from polars.testing import assert_frame_equal
 
 from cfa.stf.routine.utils import language_utils
 from cfa.stf.routine.utils.cli_utils import run_command
@@ -15,7 +13,6 @@ from cfa.stf.routine.utils.date_utils import (
     parse_exclude_date_ranges,
 )
 from cfa.stf.routine.utils.language_utils import run_julia_script, run_r_script
-from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
 
 class TestValidationUtils:
@@ -98,89 +95,6 @@ class TestValidationUtils:
         """Test parsing invalid date range strings raises appropriate errors."""
         with pytest.raises(ValueError, match=error_match):
             parse_exclude_date_ranges(input_str)
-
-
-class TestDataWranglingUtils:
-    """Tests for data loading and processing utilities."""
-
-    @pytest.mark.parametrize(
-        "present_var",
-        [
-            "observed_ed_visits",
-            "other_ed_visits",
-        ],
-    )
-    def test_append_prop_ed_data_rejects_incomplete_nssp(
-        self,
-        present_var,
-    ):
-        data = pl.DataFrame(
-            {
-                "date": ["2024-01-01"],
-                "location": ["US"],
-                ".variable": [present_var],
-                ".value": [5],
-            }
-        )
-
-        with pytest.raises(ValueError, match="incomplete NSSP data"):
-            append_prop_ed_data(data)
-
-    def test_append_prop_ed_data_appends_proportions(self):
-        data = pl.DataFrame(
-            {
-                "date": ["2024-01-01", "2024-01-01"],
-                "location": ["US", "US"],
-                ".variable": ["observed_ed_visits", "other_ed_visits"],
-                ".value": [2, 8],
-            }
-        )
-
-        result = append_prop_ed_data(data)
-        expected = pl.DataFrame(
-            {
-                "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
-                "location": ["US", "US", "US"],
-                ".variable": [
-                    "observed_ed_visits",
-                    "other_ed_visits",
-                    "prop_disease_ed_visits",
-                ],
-                ".value": [2.0, 8.0, 0.2],
-            }
-        )
-        assert_frame_equal(result, expected)
-
-    def test_append_prop_ed_data_allows_variable_names(self):
-        data = pl.DataFrame(
-            {
-                "date": ["2024-01-01", "2024-01-01"],
-                "location": ["US", "US"],
-                ".variable": ["num_visits", "denom_other_visits"],
-                ".value": [3, 7],
-            }
-        )
-
-        result = append_prop_ed_data(
-            data,
-            observed_var="num_visits",
-            other_var="denom_other_visits",
-            prop_var="prop_num_visits",
-        )
-
-        expected = pl.DataFrame(
-            {
-                "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
-                "location": ["US", "US", "US"],
-                ".variable": [
-                    "denom_other_visits",
-                    "num_visits",
-                    "prop_num_visits",
-                ],
-                ".value": [7.0, 3.0, 0.3],
-            }
-        )
-        assert_frame_equal(result, expected)
 
 
 class TestCLIUtils:

--- a/tests/utils/test_common_utils.py
+++ b/tests/utils/test_common_utils.py
@@ -103,8 +103,7 @@ class TestValidationUtils:
 class TestDataWranglingUtils:
     """Tests for data loading and processing utilities."""
 
-    def test_append_prop_data_to_combined_data_skips_non_nssp_data(self, tmp_path):
-        data_path = tmp_path / "combined_data.tsv"
+    def test_append_prop_data_to_combined_data_skips_non_nssp_data(self):
         original = pl.DataFrame(
             {
                 "date": ["2024-01-01"],
@@ -113,11 +112,7 @@ class TestDataWranglingUtils:
                 ".value": [5],
             }
         )
-        original.write_csv(data_path, separator="\t")
-
-        append_prop_data_to_combined_data(data_path)
-
-        result = pl.read_csv(data_path, separator="\t")
+        result = append_prop_data_to_combined_data(original)
         assert_frame_equal(result, original)
 
     @pytest.mark.parametrize(
@@ -126,36 +121,31 @@ class TestDataWranglingUtils:
     )
     def test_append_prop_data_to_combined_data_rejects_incomplete_nssp(
         self,
-        tmp_path,
         present_var,
     ):
-        data_path = tmp_path / "combined_data.tsv"
-        pl.DataFrame(
+        data = pl.DataFrame(
             {
                 "date": ["2024-01-01"],
                 "location": ["US"],
                 ".variable": [present_var],
                 ".value": [5],
             }
-        ).write_csv(data_path, separator="\t")
+        )
 
         with pytest.raises(ValueError, match="incomplete NSSP data"):
-            append_prop_data_to_combined_data(data_path)
+            append_prop_data_to_combined_data(data)
 
-    def test_append_prop_data_to_combined_data_updates_tsv(self, tmp_path):
-        data_path = tmp_path / "combined_data.tsv"
-        pl.DataFrame(
+    def test_append_prop_data_to_combined_data_appends_proportions(self):
+        data = pl.DataFrame(
             {
                 "date": ["2024-01-01", "2024-01-01"],
                 "location": ["US", "US"],
                 ".variable": ["observed_ed_visits", "other_ed_visits"],
                 ".value": [2, 8],
             }
-        ).write_csv(data_path, separator="\t")
+        )
 
-        append_prop_data_to_combined_data(data_path)
-
-        result = pl.read_csv(data_path, separator="\t")
+        result = append_prop_data_to_combined_data(data)
         expected = pl.DataFrame(
             {
                 "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
@@ -170,25 +160,23 @@ class TestDataWranglingUtils:
         )
         assert_frame_equal(result, expected)
 
-    def test_append_prop_data_to_combined_data_allows_variable_names(self, tmp_path):
-        data_path = tmp_path / "combined_data.tsv"
-        pl.DataFrame(
+    def test_append_prop_data_to_combined_data_allows_variable_names(self):
+        data = pl.DataFrame(
             {
                 "date": ["2024-01-01", "2024-01-01"],
                 "location": ["US", "US"],
                 ".variable": ["num_visits", "denom_other_visits"],
                 ".value": [3, 7],
             }
-        ).write_csv(data_path, separator="\t")
+        )
 
-        append_prop_data_to_combined_data(
-            data_path,
+        result = append_prop_data_to_combined_data(
+            data,
             observed_var="num_visits",
             other_var="denom_other_visits",
             prop_var="prop_num_visits",
         )
 
-        result = pl.read_csv(data_path, separator="\t")
         expected = pl.DataFrame(
             {
                 "date": ["2024-01-01", "2024-01-01", "2024-01-01"],

--- a/tests/utils/test_common_utils.py
+++ b/tests/utils/test_common_utils.py
@@ -15,7 +15,7 @@ from cfa.stf.routine.utils.date_utils import (
     parse_exclude_date_ranges,
 )
 from cfa.stf.routine.utils.language_utils import run_julia_script, run_r_script
-from cfa.stf.routine.utils.prop_utils import append_prop_data_to_combined_data
+from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
 
 class TestValidationUtils:
@@ -103,7 +103,7 @@ class TestValidationUtils:
 class TestDataWranglingUtils:
     """Tests for data loading and processing utilities."""
 
-    def test_append_prop_data_to_combined_data_skips_non_nssp_data(self):
+    def test_append_prop_ed_data_rejects_missing_nssp_data(self):
         original = pl.DataFrame(
             {
                 "date": ["2024-01-01"],
@@ -112,14 +112,14 @@ class TestDataWranglingUtils:
                 ".value": [5],
             }
         )
-        result = append_prop_data_to_combined_data(original)
-        assert_frame_equal(result, original)
+        with pytest.raises(ValueError, match="incomplete NSSP data"):
+            append_prop_ed_data(original)
 
     @pytest.mark.parametrize(
         "present_var",
         ["observed_ed_visits", "other_ed_visits"],
     )
-    def test_append_prop_data_to_combined_data_rejects_incomplete_nssp(
+    def test_append_prop_ed_data_rejects_incomplete_nssp(
         self,
         present_var,
     ):
@@ -133,9 +133,9 @@ class TestDataWranglingUtils:
         )
 
         with pytest.raises(ValueError, match="incomplete NSSP data"):
-            append_prop_data_to_combined_data(data)
+            append_prop_ed_data(data)
 
-    def test_append_prop_data_to_combined_data_appends_proportions(self):
+    def test_append_prop_ed_data_appends_proportions(self):
         data = pl.DataFrame(
             {
                 "date": ["2024-01-01", "2024-01-01"],
@@ -145,7 +145,7 @@ class TestDataWranglingUtils:
             }
         )
 
-        result = append_prop_data_to_combined_data(data)
+        result = append_prop_ed_data(data)
         expected = pl.DataFrame(
             {
                 "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
@@ -160,7 +160,7 @@ class TestDataWranglingUtils:
         )
         assert_frame_equal(result, expected)
 
-    def test_append_prop_data_to_combined_data_allows_variable_names(self):
+    def test_append_prop_ed_data_allows_variable_names(self):
         data = pl.DataFrame(
             {
                 "date": ["2024-01-01", "2024-01-01"],
@@ -170,7 +170,7 @@ class TestDataWranglingUtils:
             }
         )
 
-        result = append_prop_data_to_combined_data(
+        result = append_prop_ed_data(
             data,
             observed_var="num_visits",
             other_var="denom_other_visits",

--- a/tests/utils/test_common_utils.py
+++ b/tests/utils/test_common_utils.py
@@ -106,7 +106,6 @@ class TestDataWranglingUtils:
     @pytest.mark.parametrize(
         "present_var",
         [
-            "observed_hospital_admissions",
             "observed_ed_visits",
             "other_ed_visits",
         ],

--- a/tests/utils/test_common_utils.py
+++ b/tests/utils/test_common_utils.py
@@ -103,21 +103,13 @@ class TestValidationUtils:
 class TestDataWranglingUtils:
     """Tests for data loading and processing utilities."""
 
-    def test_append_prop_ed_data_rejects_missing_nssp_data(self):
-        original = pl.DataFrame(
-            {
-                "date": ["2024-01-01"],
-                "location": ["US"],
-                ".variable": ["observed_hospital_admissions"],
-                ".value": [5],
-            }
-        )
-        with pytest.raises(ValueError, match="incomplete NSSP data"):
-            append_prop_ed_data(original)
-
     @pytest.mark.parametrize(
         "present_var",
-        ["observed_ed_visits", "other_ed_visits"],
+        [
+            "observed_hospital_admissions",
+            "observed_ed_visits",
+            "other_ed_visits",
+        ],
     )
     def test_append_prop_ed_data_rejects_incomplete_nssp(
         self,

--- a/tests/utils/test_data_utils.py
+++ b/tests/utils/test_data_utils.py
@@ -6,26 +6,9 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 from cfa.stf.routine.utils.data_utils import (
-    aggregate_ed_visits_to_epiweekly,
     aggregate_long_to_epiweekly,
+    aggregate_nssp_to_epiweekly,
 )
-
-
-def _with_metadata(data: pl.DataFrame, *, resolution: str) -> pl.DataFrame:
-    return data.with_columns(
-        geo_value=pl.lit("CA"),
-        disease=pl.lit("flu"),
-        data_type=pl.lit("train"),
-        resolution=pl.lit(resolution),
-    ).select(
-        "date",
-        "geo_value",
-        "disease",
-        "data_type",
-        "resolution",
-        ".variable",
-        ".value",
-    )
 
 
 def test_aggregate_long_to_epiweekly_accepts_date_and_value_columns():
@@ -59,47 +42,29 @@ def test_aggregate_long_to_epiweekly_accepts_date_and_value_columns():
     )
 
 
-def test_aggregate_ed_visits_to_epiweekly_preserves_other_data():
-    daily_ed_data = _with_metadata(
-        pl.DataFrame(
-            {
-                "date": pl.date_range(
-                    dt.date(2025, 1, 5), dt.date(2025, 1, 18), eager=True
-                ),
-                "observed_ed_visits": pl.int_range(1, 15, eager=True),
-                "other_ed_visits": 9,
-            }
-        ).unpivot(
-            on=["observed_ed_visits", "other_ed_visits"],
-            index="date",
-            variable_name=".variable",
-            value_name=".value",
-        ),
-        resolution="daily",
+def test_aggregate_nssp_to_epiweekly_preserves_wide_source_schema():
+    data = pl.DataFrame(
+        {
+            "date": pl.date_range(
+                dt.date(2025, 1, 5), dt.date(2025, 1, 18), eager=True
+            ),
+            "state_abb": ["CA"] * 14,
+            "observed_ed_visits": pl.int_range(1, 15, eager=True),
+            "other_ed_visits": [9] * 14,
+            "data_type": ["train"] * 14,
+            "resolution": ["daily"] * 14,
+        }
     )
-    hospital_data = _with_metadata(
-        pl.DataFrame(
-            {
-                "date": [dt.date(2025, 1, 11)],
-                ".variable": ["observed_hospital_admissions"],
-                ".value": [3],
-            }
-        ),
-        resolution="epiweekly",
-    )
-    result = aggregate_ed_visits_to_epiweekly(pl.concat([daily_ed_data, hospital_data]))
-    expected = _with_metadata(
-        pl.DataFrame(
-            [
-                (dt.date(2025, 1, 11), "observed_ed_visits", 28),
-                (dt.date(2025, 1, 11), "observed_hospital_admissions", 3),
-                (dt.date(2025, 1, 11), "other_ed_visits", 63),
-                (dt.date(2025, 1, 18), "observed_ed_visits", 77),
-                (dt.date(2025, 1, 18), "other_ed_visits", 63),
-            ],
-            schema={"date": pl.Date, ".variable": pl.String, ".value": pl.Int64},
-            orient="row",
-        ),
-        resolution="epiweekly",
+
+    result = aggregate_nssp_to_epiweekly(data)
+    expected = pl.DataFrame(
+        {
+            "date": [dt.date(2025, 1, 11), dt.date(2025, 1, 18)],
+            "state_abb": ["CA", "CA"],
+            "observed_ed_visits": [28, 77],
+            "other_ed_visits": [63, 63],
+            "data_type": ["train", "train"],
+            "resolution": ["epiweekly", "epiweekly"],
+        }
     )
     assert_frame_equal(result, expected)

--- a/tests/utils/test_data_utils.py
+++ b/tests/utils/test_data_utils.py
@@ -6,8 +6,8 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 from cfa.stf.routine.utils.data_utils import (
+    aggregate_ed_visits_to_epiweekly,
     aggregate_long_to_epiweekly,
-    generate_epiweekly_data,
 )
 
 
@@ -59,9 +59,7 @@ def test_aggregate_long_to_epiweekly_accepts_date_and_value_columns():
     )
 
 
-def test_generate_epiweekly_data_aggregates_ed_visits_and_preserves_other_data(
-    tmp_path,
-):
+def test_aggregate_ed_visits_to_epiweekly_preserves_other_data():
     daily_ed_data = _with_metadata(
         pl.DataFrame(
             {
@@ -89,12 +87,7 @@ def test_generate_epiweekly_data_aggregates_ed_visits_and_preserves_other_data(
         ),
         resolution="epiweekly",
     )
-    combined_data_path = tmp_path / "combined_data.tsv"
-    pl.concat([daily_ed_data, hospital_data]).write_csv(
-        combined_data_path, separator="\t"
-    )
-
-    result = generate_epiweekly_data(combined_data_path)
+    result = aggregate_ed_visits_to_epiweekly(pl.concat([daily_ed_data, hospital_data]))
     expected = _with_metadata(
         pl.DataFrame(
             [

--- a/tests/utils/test_prop_utils.py
+++ b/tests/utils/test_prop_utils.py
@@ -3,10 +3,93 @@
 import datetime as dt
 
 import polars as pl
+import pytest
 from cfa.stf.forecasttools import read_tabular, write_tabular
 from polars.testing import assert_frame_equal
 
-from cfa.stf.routine.utils.prop_utils import create_prop_fusion_model
+from cfa.stf.routine.utils.prop_utils import (
+    append_prop_ed_data,
+    create_prop_fusion_model,
+)
+
+
+@pytest.mark.parametrize(
+    "present_var",
+    [
+        "observed_ed_visits",
+        "other_ed_visits",
+    ],
+)
+def test_append_prop_ed_data_rejects_incomplete_nssp(present_var):
+    data = pl.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "location": ["US"],
+            ".variable": [present_var],
+            ".value": [5],
+        }
+    )
+
+    with pytest.raises(ValueError, match="incomplete NSSP data"):
+        append_prop_ed_data(data)
+
+
+def test_append_prop_ed_data_appends_proportions():
+    data = pl.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01"],
+            "location": ["US", "US"],
+            ".variable": ["observed_ed_visits", "other_ed_visits"],
+            ".value": [2, 8],
+        }
+    )
+
+    result = append_prop_ed_data(data)
+    expected = pl.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+            "location": ["US", "US", "US"],
+            ".variable": [
+                "observed_ed_visits",
+                "other_ed_visits",
+                "prop_disease_ed_visits",
+            ],
+            ".value": [2.0, 8.0, 0.2],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_append_prop_ed_data_allows_variable_names():
+    data = pl.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01"],
+            "location": ["US", "US"],
+            ".variable": ["num_visits", "denom_other_visits"],
+            ".value": [3, 7],
+        }
+    )
+
+    result = append_prop_ed_data(
+        data,
+        observed_var="num_visits",
+        other_var="denom_other_visits",
+        prop_var="prop_num_visits",
+    )
+
+    expected = pl.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-01", "2024-01-01"],
+            "location": ["US", "US", "US"],
+            ".variable": [
+                "denom_other_visits",
+                "num_visits",
+                "prop_num_visits",
+            ],
+            ".value": [7.0, 3.0, 0.3],
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def _model_frame(


### PR DESCRIPTION
## Summary
- track each surveillance source resolution and aggregate NSSP ED visits once during loading, keeping `data_for_model_fit.json` and `combined_data.tsv` consistent
- replace model-specific post-serialization transforms with a declarative `ed_visit_input_resolution` used by Fable, EpiAutoGP, and Dagster
- simplify common serialization and compute ED-visit proportions in memory while preserving NHSN-only runs
- update documentation and tests for daily and epiweekly inputs

## Testing
- `uv run pytest -m "not pipeline_e2e and not model_integration" -q` — 160 passed, 4 deselected
- `uv run ruff check src/cfa/stf/routine tests` — passed