### PR TITLE
Require manual trigger for end-to-end test

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -141,9 +141,25 @@ jobs:
                     exit 1
                   fi
 
-    end-to-end-test:
+    approve-end-to-end-test:
         needs: acr-import
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        environment: end-to-end-test-approval
+        name: End-to-end test via Dagster (optional)
+        steps:
+          - name: Approval received
+            run: echo "Running the optional end-to-end test"
+
+    end-to-end-test:
+        needs: [ acr-import, approve-end-to-end-test ]
+        if: |-
+          always() &&
+          needs.acr-import.result == 'success' &&
+          (
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'pull_request' && needs.approve-end-to-end-test.result == 'success')
+          )
         runs-on: ubuntu-latest
         permissions:
           id-token: write # This is required for requesting the JWT

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -143,6 +143,7 @@ jobs:
 
     end-to-end-test:
         needs: acr-import
+        if: github.event_name == 'workflow_dispatch'
         runs-on: ubuntu-latest
         permissions:
           id-token: write # This is required for requesting the JWT
@@ -230,6 +231,11 @@ jobs:
 
     check_and_deploy_dagster_code:
       needs: [ build-pipeline-image, acr-import, end-to-end-test ]
+      if: |-
+        always() &&
+        needs.build-pipeline-image.result == 'success' &&
+        needs.acr-import.result == 'success' &&
+        (needs.end-to-end-test.result == 'success' || needs.end-to-end-test.result == 'skipped')
       # Conditional step execution that runs only when:
       # the workflow is manually dispatched and the 'push_to_dagster' input is set to 'yes'
       # OR


### PR DESCRIPTION
## Summary
- show the Dagster end-to-end test as an optional approval-gated check on pull requests
- run the test after a cfa-predict-stf reviewer starts the waiting job
- keep image build and ACR import running automatically for push and pull request events
- preserve downstream deployment behavior when the test is intentionally skipped while still requiring successful build and import jobs

## Testing
- uv run pre-commit run --files .github/workflows/containers.yaml
- git diff --check

Closes #1249