### PR TITLE
Streamline pivoting in data_access and prep_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -395,7 +395,7 @@ private_data/*
 .vscode/settings.json
 
 # Ignore end to end test output
-/tests/end_to_end_test_output/
+/test_output/
 
 # Azure configuration files
 azureconfig.env

--- a/Justfile
+++ b/Justfile
@@ -25,36 +25,26 @@ e2e data_mode="auto":
       --e2e-force \
       --e2e-data-mode "{{data_mode}}"
 
-# Test Fable for one disease and location and retain its output.
+# Test Fable for one disease and location with mock or real DataOps data.
 test-fable data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_fable_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}" \
-      --e2e-output-dir "{{e2e_output_dir}}/fable-{{disease}}-{{location}}" \
-      --e2e-force
+      --model-test-disease "{{disease}}"
 
-# Test PyRenew for one disease and location and retain its output.
+# Test PyRenew for one disease and location with mock or real DataOps data.
 test-pyrenew data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_pyrenew_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}" \
-      --e2e-output-dir "{{e2e_output_dir}}/pyrenew-{{disease}}-{{location}}" \
-      --e2e-force
+      --model-test-disease "{{disease}}"
 
-# Test EpiAutoGP for one disease and location and retain its output.
+# Test EpiAutoGP for one disease and location with mock or real DataOps data.
 test-epiautogp data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_epiautogp_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}" \
-      --e2e-output-dir "{{e2e_output_dir}}/epiautogp-{{disease}}-{{location}}" \
-      --e2e-force
-
-# Remove all retained end-to-end and single-model test outputs.
-clean-outputs:
-    rm -rf -- "{{e2e_output_dir}}"
+      --model-test-disease "{{disease}}"

--- a/Justfile
+++ b/Justfile
@@ -25,26 +25,36 @@ e2e data_mode="auto":
       --e2e-force \
       --e2e-data-mode "{{data_mode}}"
 
-# Test Fable for one disease and location with mock or real DataOps data.
+# Test Fable for one disease and location and retain its output.
 test-fable data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_fable_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}"
+      --model-test-disease "{{disease}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/fable-{{disease}}-{{location}}" \
+      --e2e-force
 
-# Test PyRenew for one disease and location with mock or real DataOps data.
+# Test PyRenew for one disease and location and retain its output.
 test-pyrenew data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_pyrenew_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}"
+      --model-test-disease "{{disease}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/pyrenew-{{disease}}-{{location}}" \
+      --e2e-force
 
-# Test EpiAutoGP for one disease and location with mock or real DataOps data.
+# Test EpiAutoGP for one disease and location and retain its output.
 test-epiautogp data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_epiautogp_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}"
+      --model-test-disease "{{disease}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/epiautogp-{{disease}}-{{location}}" \
+      --e2e-force
+
+# Remove all retained end-to-end and single-model test outputs.
+clean-outputs:
+    rm -rf -- "{{e2e_output_dir}}"

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set shell := ["bash", "-uc"]
 
-e2e_output_dir := "tests/end_to_end_test_output"
+e2e_output_dir := "test_output"
 
 default:
     @just --list
@@ -32,7 +32,7 @@ test-fable data_mode="auto" location="CA" disease="covid":
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
       --model-test-disease "{{disease}}" \
-      --e2e-output-dir "{{e2e_output_dir}}/fable-{{disease}}-{{location}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/fable" \
       --e2e-force
 
 # Test PyRenew for one disease and location and retain its output.
@@ -42,7 +42,7 @@ test-pyrenew data_mode="auto" location="CA" disease="covid":
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
       --model-test-disease "{{disease}}" \
-      --e2e-output-dir "{{e2e_output_dir}}/pyrenew-{{disease}}-{{location}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/pyrenew" \
       --e2e-force
 
 # Test EpiAutoGP for one disease and location and retain its output.
@@ -52,7 +52,7 @@ test-epiautogp data_mode="auto" location="CA" disease="covid":
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
       --model-test-disease "{{disease}}" \
-      --e2e-output-dir "{{e2e_output_dir}}/epiautogp-{{disease}}-{{location}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/epiautogp" \
       --e2e-force
 
 # Remove all retained end-to-end and single-model test outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ source-include = [
 ]
 source-exclude = [
     ".DS_Store",
-    "/tests/end_to_end_test_output",
+    "/test_output",
 ]
 
 [tool.dg]

--- a/src/cfa/stf/routine/data/data_access.py
+++ b/src/cfa/stf/routine/data/data_access.py
@@ -119,7 +119,7 @@ def _normalize_nssp_data(
         )
 
     index_columns = ["date", "state_abb"]
-    observed = source_data.filter(pl.col("disease") == observed_diseases[0]).select(
+    observed = source_data.filter(pl.col("disease") != "total").select(
         *index_columns,
         pl.col("value").alias("observed_ed_visits"),
     )

--- a/src/cfa/stf/routine/data/data_access.py
+++ b/src/cfa/stf/routine/data/data_access.py
@@ -100,6 +100,57 @@ def resolve_nssp_report_date() -> dt.date:
     return _resolved_version_date(version, dataset="NSSP gold")
 
 
+def _normalize_nssp_data(
+    source_data: pl.DataFrame,
+    *,
+    disease: str,
+    last_training_date: dt.date,
+) -> pl.DataFrame:
+    """Normalize disease and total ED visits without a wide-format round trip."""
+    index_columns = ["date", "state_abb"]
+    observed = source_data.filter(pl.col("disease") == disease).select(
+        *index_columns,
+        pl.col("value").alias("observed_ed_visits"),
+    )
+    totals = source_data.filter(pl.col("disease") == "total").select(
+        *index_columns,
+        pl.col("value").alias("total_ed_visits"),
+    )
+    visits = observed.join(
+        totals,
+        on=index_columns,
+        how="full",
+        coalesce=True,
+        validate="1:1",
+    )
+
+    return (
+        pl.concat(
+            [
+                visits.select(
+                    *index_columns,
+                    pl.lit("observed_ed_visits").alias(".variable"),
+                    pl.col("observed_ed_visits").alias(".value"),
+                ),
+                visits.select(
+                    *index_columns,
+                    pl.lit("other_ed_visits").alias(".variable"),
+                    (pl.col("total_ed_visits") - pl.col("observed_ed_visits")).alias(
+                        ".value"
+                    ),
+                ),
+            ]
+        )
+        .with_columns(
+            data_type=pl.when(pl.col("date") <= last_training_date)
+            .then(pl.lit("train"))
+            .otherwise(pl.lit("eval")),
+            resolution=pl.lit("daily"),
+        )
+        .sort("date", "state_abb", ".variable")
+    )
+
+
 def _load_dataops_nssp(
     *,
     loc_abb: str,
@@ -121,22 +172,10 @@ def _load_dataops_nssp(
         latest_observed_date=source_data.get_column("date").max(),
         run_date=run_date,
     )
-    data = (
-        source_data.filter(pl.col("disease").is_in([disease, "total"]))
-        .pivot(
-            on="disease",
-            values="value",
-        )
-        .rename({disease: "observed_ed_visits"})
-        .with_columns(
-            other_ed_visits=pl.col("total") - pl.col("observed_ed_visits"),
-            data_type=pl.when(pl.col("date") <= last_training_date)
-            .then(pl.lit("train"))
-            .otherwise(pl.lit("eval")),
-            resolution=pl.lit("daily"),
-        )
-        .drop("total", "target_type")
-        .sort("date")
+    data = _normalize_nssp_data(
+        source_data,
+        disease=disease,
+        last_training_date=last_training_date,
     )
     return NSSPData(data=data, freshness=freshness, resolution="daily")
 

--- a/src/cfa/stf/routine/data/data_access.py
+++ b/src/cfa/stf/routine/data/data_access.py
@@ -103,12 +103,23 @@ def resolve_nssp_report_date() -> dt.date:
 def _normalize_nssp_data(
     source_data: pl.DataFrame,
     *,
-    disease: str,
     last_training_date: dt.date,
 ) -> pl.DataFrame:
     """Normalize disease and total ED visits without a wide-format round trip."""
+    observed_diseases = (
+        source_data.filter(pl.col("disease") != "total")
+        .get_column("disease")
+        .unique()
+        .sort()
+        .to_list()
+    )
+    if len(observed_diseases) != 1:
+        raise ValueError(
+            f"Expected exactly one non-total NSSP disease; found {observed_diseases}"
+        )
+
     index_columns = ["date", "state_abb"]
-    observed = source_data.filter(pl.col("disease") == disease).select(
+    observed = source_data.filter(pl.col("disease") == observed_diseases[0]).select(
         *index_columns,
         pl.col("value").alias("observed_ed_visits"),
     )
@@ -174,7 +185,6 @@ def _load_dataops_nssp(
     )
     data = _normalize_nssp_data(
         source_data,
-        disease=disease,
         last_training_date=last_training_date,
     )
     return NSSPData(data=data, freshness=freshness, resolution="daily")

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -16,6 +16,7 @@ from cfa.stf.routine.data.data_access import (
     NHSNData,
     NSSPData,
     SurveillanceInputs,
+    _normalize_nssp_data,
 )
 from cfa.stf.routine.data.hubverse_nowcast import (
     HUBVERSE_MODEL_OUTPUT_SUBDIR,
@@ -261,21 +262,10 @@ def make_surveillance_inputs(
 
     nssp = (
         NSSPData(
-            data=(
-                nssp_data.pivot(
-                    on="disease",
-                    values="value",
-                )
-                .rename({disease: "observed_ed_visits"})
-                .with_columns(
-                    other_ed_visits=pl.col("total") - pl.col("observed_ed_visits"),
-                    data_type=pl.when(pl.col("date") <= last_training_date)
-                    .then(pl.lit("train"))
-                    .otherwise(pl.lit("eval")),
-                    resolution=pl.lit("daily"),
-                )
-                .drop("total", "target_type")
-                .sort("date")
+            data=_normalize_nssp_data(
+                nssp_data,
+                disease=disease,
+                last_training_date=last_training_date,
             ),
             freshness=nssp_freshness,
             resolution="daily",

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -264,7 +264,6 @@ def make_surveillance_inputs(
         NSSPData(
             data=_normalize_nssp_data(
                 nssp_data,
-                disease=disease,
                 last_training_date=last_training_date,
             ),
             freshness=nssp_freshness,

--- a/src/cfa/stf/routine/data/prep_data.py
+++ b/src/cfa/stf/routine/data/prep_data.py
@@ -3,7 +3,6 @@ import logging
 from typing import TYPE_CHECKING
 
 import polars as pl
-import polars.selectors as cs
 from cfa.stf.forecasttools import write_tabular
 
 from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
@@ -20,14 +19,7 @@ def combine_surveillance_data(
 ) -> pl.DataFrame:
     source_frames = []
     if nssp_data is not None:
-        source_frames.append(
-            nssp_data.unpivot(
-                on=["observed_ed_visits", "other_ed_visits"],
-                variable_name=".variable",
-                index=cs.exclude(["observed_ed_visits", "other_ed_visits"]),
-                value_name=".value",
-            )
-        )
+        source_frames.append(nssp_data)
 
     if nhsn_data is not None:
         source_frames.append(
@@ -72,6 +64,11 @@ def serialize_data(
 
     nssp_training_data = (
         forecast_run.nssp.data.filter(pl.col("data_type") == "train")
+        .pivot(
+            on=".variable",
+            index=["date", "state_abb", "data_type", "resolution"],
+            values=".value",
+        )
         .drop("resolution", "data_type")
         .rename({"state_abb": "geo_value"})
         if forecast_run.nssp is not None

--- a/src/cfa/stf/routine/epiautogp/prep_epiautogp_data.py
+++ b/src/cfa/stf/routine/epiautogp/prep_epiautogp_data.py
@@ -10,6 +10,7 @@ import polars as pl
 from cfa.stf.routine.data.nowcast import NowcastData, NowcastSource
 from cfa.stf.routine.epiautogp.config import EpiAutoGPConfig
 from cfa.stf.routine.forecast_run import ForecastRun
+from cfa.stf.routine.utils.prop_utils import append_prop_ed_data
 
 
 def _validate_epiautogp_parameters(
@@ -78,19 +79,21 @@ def _extract_model_series(
                 f"NSSP data resolution {source.resolution!r} does not match "
                 f"EpiAutoGP frequency {config.frequency!r}"
             )
-        value = {
-            "observed": pl.col("observed_ed_visits"),
-            "other": pl.col("other_ed_visits"),
-            "pct": (
-                pl.col("observed_ed_visits")
-                / (pl.col("observed_ed_visits") + pl.col("other_ed_visits"))
-                * 100
-            ),
+        variable = {
+            "observed": "observed_ed_visits",
+            "other": "other_ed_visits",
+            "pct": "prop_disease_ed_visits",
         }[config.ed_visit_type]
-        data = source.data.select(
+        source_data = (
+            append_prop_ed_data(source.data)
+            if config.ed_visit_type == "pct"
+            else source.data
+        )
+        scale = 100 if config.ed_visit_type == "pct" else 1
+        data = source_data.filter(pl.col(".variable") == variable).select(
             "date",
             "data_type",
-            value.cast(pl.Float64).alias("value"),
+            (pl.col(".value") * scale).cast(pl.Float64).alias("value"),
         )
     else:
         source = forecast_run.nhsn

--- a/src/cfa/stf/routine/epiautogp/prep_epiautogp_data.py
+++ b/src/cfa/stf/routine/epiautogp/prep_epiautogp_data.py
@@ -85,15 +85,14 @@ def _extract_model_series(
             "pct": "prop_disease_ed_visits",
         }[config.ed_visit_type]
         source_data = (
-            append_prop_ed_data(source.data)
+            append_prop_ed_data(source.data).with_columns(pl.col(".value") * 100)
             if config.ed_visit_type == "pct"
             else source.data
         )
-        scale = 100 if config.ed_visit_type == "pct" else 1
         data = source_data.filter(pl.col(".variable") == variable).select(
             "date",
             "data_type",
-            (pl.col(".value") * scale).cast(pl.Float64).alias("value"),
+            pl.col(".value").cast(pl.Float64).alias("value"),
         )
     else:
         source = forecast_run.nhsn

--- a/src/cfa/stf/routine/utils/data_utils.py
+++ b/src/cfa/stf/routine/utils/data_utils.py
@@ -30,18 +30,9 @@ def aggregate_long_to_epiweekly(
 
 
 def aggregate_nssp_to_epiweekly(data: pl.DataFrame) -> pl.DataFrame:
-    """Aggregate wide daily NSSP data to complete MMWR weeks."""
-    value_columns = ["observed_ed_visits", "other_ed_visits"]
-    id_columns = [column for column in data.columns if column not in value_columns]
-    long_data = data.unpivot(
-        on=value_columns,
-        index=id_columns,
-        variable_name=".variable",
-        value_name=".value",
-    )
+    """Aggregate long daily NSSP data to complete MMWR weeks."""
     return (
-        aggregate_long_to_epiweekly(long_data)
-        .pivot(on=".variable", index=id_columns, values=".value")
+        aggregate_long_to_epiweekly(data)
         .select(data.columns)
-        .sort("date", "state_abb")
+        .sort("date", "state_abb", ".variable")
     )

--- a/tests/data/test_data_access.py
+++ b/tests/data/test_data_access.py
@@ -54,18 +54,16 @@ def test_load_dataops_nssp_returns_normalized_source(monkeypatch):
                 dt.date(2026, 1, 8),
                 dt.date(2026, 1, 7),
                 dt.date(2026, 1, 7),
-                dt.date(2026, 1, 7),
             ],
-            "state_abb": ["CA"] * 5,
+            "state_abb": ["CA"] * 4,
             "disease": [
                 "covid",
                 "total",
                 "total",
-                "flu",
                 "covid",
             ],
-            "target_type": ["inc ed visits"] * 5,
-            "value": [12, 120, 100, 8, 10],
+            "target_type": ["inc ed visits"] * 4,
+            "value": [12, 120, 100, 10],
         }
     )
     monkeypatch.setattr(
@@ -116,6 +114,23 @@ def test_load_dataops_nssp_returns_normalized_source(monkeypatch):
         "start_date": dt.date(2025, 12, 1),
         "lazy": False,
     }
+
+
+def test_normalize_nssp_data_requires_one_non_total_disease():
+    source_data = pl.DataFrame(
+        {
+            "date": [dt.date(2026, 1, 7)] * 3,
+            "state_abb": ["CA"] * 3,
+            "disease": ["covid", "flu", "total"],
+            "value": [10, 8, 100],
+        }
+    )
+
+    with pytest.raises(ValueError, match="exactly one non-total NSSP disease"):
+        data_access._normalize_nssp_data(
+            source_data,
+            last_training_date=dt.date(2026, 1, 7),
+        )
 
 
 def test_load_dataops_nhsn_returns_normalized_source(monkeypatch):

--- a/tests/data/test_data_access.py
+++ b/tests/data/test_data_access.py
@@ -89,18 +89,18 @@ def test_load_dataops_nssp_returns_normalized_source(monkeypatch):
 
     expected = pl.DataFrame(
         {
-            "date": [dt.date(2026, 1, 7), dt.date(2026, 1, 8)],
-            "observed_ed_visits": [10, 12],
-            "other_ed_visits": [90, 108],
-            "data_type": ["train", "eval"],
-            "resolution": ["daily", "daily"],
+            "date": [dt.date(2026, 1, 7)] * 2 + [dt.date(2026, 1, 8)] * 2,
+            ".variable": ["observed_ed_visits", "other_ed_visits"] * 2,
+            ".value": [10, 90, 12, 108],
+            "data_type": ["train"] * 2 + ["eval"] * 2,
+            "resolution": ["daily"] * 4,
         }
     )
     assert_frame_equal(
         result.data.select(
             "date",
-            "observed_ed_visits",
-            "other_ed_visits",
+            ".variable",
+            ".value",
             "data_type",
             "resolution",
         ),
@@ -377,12 +377,12 @@ def test_load_surveillance_inputs_uses_dataops_loaders(monkeypatch):
     nssp = data_access.NSSPData(
         data=pl.DataFrame(
             {
-                "date": [dt.date(2026, 1, 8)],
-                "state_abb": ["CA"],
-                "observed_ed_visits": [10],
-                "other_ed_visits": [90],
-                "data_type": ["eval"],
-                "resolution": ["daily"],
+                "date": [dt.date(2026, 1, 8)] * 2,
+                "state_abb": ["CA"] * 2,
+                ".variable": ["observed_ed_visits", "other_ed_visits"],
+                ".value": [10, 90],
+                "data_type": ["eval"] * 2,
+                "resolution": ["daily"] * 2,
             }
         ),
         freshness=freshness("nssp", dt.date(2026, 1, 8)),
@@ -430,16 +430,16 @@ def test_load_surveillance_inputs_uses_dataops_loaders(monkeypatch):
     assert surveillance.loc_pop == 39_000_000
     expected_nssp = pl.DataFrame(
         {
-            "observed_ed_visits": [10],
-            "other_ed_visits": [90],
-            "data_type": ["eval"],
-            "resolution": ["daily"],
+            ".variable": ["observed_ed_visits", "other_ed_visits"],
+            ".value": [10, 90],
+            "data_type": ["eval"] * 2,
+            "resolution": ["daily"] * 2,
         }
     )
     assert_frame_equal(
         surveillance.nssp.data.select(
-            "observed_ed_visits",
-            "other_ed_visits",
+            ".variable",
+            ".value",
             "data_type",
             "resolution",
         ),
@@ -485,12 +485,12 @@ def test_load_surveillance_inputs_stores_aggregated_nssp_data(monkeypatch):
     nssp = data_access.NSSPData(
         data=pl.DataFrame(
             {
-                "date": [dt.date(2026, 1, 8)],
-                "state_abb": ["CA"],
-                "observed_ed_visits": [10],
-                "other_ed_visits": [90],
-                "data_type": ["eval"],
-                "resolution": ["daily"],
+                "date": [dt.date(2026, 1, 8)] * 2,
+                "state_abb": ["CA"] * 2,
+                ".variable": ["observed_ed_visits", "other_ed_visits"],
+                ".value": [10, 90],
+                "data_type": ["eval"] * 2,
+                "resolution": ["daily"] * 2,
             }
         ),
         freshness=_freshness("nssp"),
@@ -535,12 +535,12 @@ def test_load_surveillance_inputs_only_loads_requested_source(
     nssp = data_access.NSSPData(
         data=pl.DataFrame(
             {
-                "date": [dt.date(2026, 1, 8)],
-                "state_abb": ["CA"],
-                "observed_ed_visits": [10],
-                "other_ed_visits": [90],
-                "data_type": ["eval"],
-                "resolution": ["daily"],
+                "date": [dt.date(2026, 1, 8)] * 2,
+                "state_abb": ["CA"] * 2,
+                ".variable": ["observed_ed_visits", "other_ed_visits"],
+                ".value": [10, 90],
+                "data_type": ["eval"] * 2,
+                "resolution": ["daily"] * 2,
             }
         ),
         freshness=_freshness("nssp"),

--- a/tests/data/test_prep_data.py
+++ b/tests/data/test_prep_data.py
@@ -89,14 +89,26 @@ def test_serialize_data_uses_run_ed_visits_for_both_artifacts(tmp_path):
         sources=("nssp",),
     )
     dates = pl.date_range(dt.date(2025, 1, 5), dt.date(2025, 1, 18), eager=True)
+    variables = ("observed_ed_visits", "other_ed_visits")
+    last_training_date = dt.date(2025, 1, 11)
+    observed_ed_visits = range(1, len(dates) + 1)
+    other_ed_visits = 9
     nssp_data = pl.DataFrame(
         {
-            "date": dates,
-            "state_abb": ["CA"] * 14,
-            "observed_ed_visits": list(range(1, 15)),
-            "other_ed_visits": [9] * 14,
-            "data_type": ["train"] * 7 + ["eval"] * 7,
-            "resolution": ["daily"] * 14,
+            "date": [date for date in dates for _variable in variables],
+            "state_abb": [forecast_run.loc for _date in dates for _ in variables],
+            ".variable": list(variables) * len(dates),
+            ".value": [
+                value
+                for observed in observed_ed_visits
+                for value in (observed, other_ed_visits)
+            ],
+            "data_type": [
+                "train" if date <= last_training_date else "eval"
+                for date in dates
+                for _variable in variables
+            ],
+            "resolution": ["daily" for _date in dates for _ in variables],
         }
     )
     nssp_data = aggregate_nssp_to_epiweekly(nssp_data)

--- a/tests/epiautogp/test_prep_epiautogp_data.py
+++ b/tests/epiautogp/test_prep_epiautogp_data.py
@@ -304,33 +304,20 @@ def _epiautogp_run(tmp_path):
         model_name="test_model",
         sources=("nssp",),
     )
+    dates = pl.date_range(run.first_training_date, report_date, eager=True)
+    variables = ("observed_ed_visits", "other_ed_visits")
+    values_by_date = ((10.0, 90.0), (20.0, 80.0), (999.0, 1.0))
     nssp_data = pl.DataFrame(
-        [
-            {
-                "date": dt.date(2024, 1, 1),
-                "state_abb": "CA",
-                "data_type": "train",
-                "resolution": "daily",
-                "observed_ed_visits": 10.0,
-                "other_ed_visits": 90.0,
-            },
-            {
-                "date": dt.date(2024, 1, 2),
-                "state_abb": "CA",
-                "data_type": "train",
-                "resolution": "daily",
-                "observed_ed_visits": 20.0,
-                "other_ed_visits": 80.0,
-            },
-            {
-                "date": dt.date(2024, 1, 3),
-                "state_abb": "CA",
-                "data_type": "eval",
-                "resolution": "daily",
-                "observed_ed_visits": 999.0,
-                "other_ed_visits": 1.0,
-            },
-        ]
+        {
+            "date": date,
+            "state_abb": run.loc,
+            "data_type": "train" if date <= run.last_training_date else "eval",
+            "resolution": run.nssp.resolution,
+            ".variable": variable,
+            ".value": value,
+        }
+        for date, daily_values in zip(dates, values_by_date, strict=True)
+        for variable, value in zip(variables, daily_values, strict=True)
     )
     surveillance = replace(
         run.surveillance,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -30,12 +30,12 @@ def make_test_surveillance_inputs(
 
     nssp_data = pl.DataFrame(
         {
-            "date": [last_training_date],
-            "state_abb": [loc_abb],
-            "observed_ed_visits": [10],
-            "other_ed_visits": [90],
-            "data_type": ["train"],
-            "resolution": ["daily"],
+            "date": [last_training_date] * 2,
+            "state_abb": [loc_abb] * 2,
+            ".variable": ["observed_ed_visits", "other_ed_visits"],
+            ".value": [10, 90],
+            "data_type": ["train"] * 2,
+            "resolution": ["daily"] * 2,
         }
     )
     nhsn_data = pl.DataFrame(

--- a/tests/utils/test_data_utils.py
+++ b/tests/utils/test_data_utils.py
@@ -42,29 +42,41 @@ def test_aggregate_long_to_epiweekly_accepts_date_and_value_columns():
     )
 
 
-def test_aggregate_nssp_to_epiweekly_preserves_wide_source_schema():
+def test_aggregate_nssp_to_epiweekly_preserves_long_source_schema():
+    dates = pl.date_range(dt.date(2025, 1, 5), dt.date(2025, 1, 18), eager=True)
+    variables = ("observed_ed_visits", "other_ed_visits")
+    observed_ed_visits = range(1, len(dates) + 1)
+    other_ed_visits = 9
     data = pl.DataFrame(
         {
-            "date": pl.date_range(
-                dt.date(2025, 1, 5), dt.date(2025, 1, 18), eager=True
-            ),
-            "state_abb": ["CA"] * 14,
-            "observed_ed_visits": pl.int_range(1, 15, eager=True),
-            "other_ed_visits": [9] * 14,
-            "data_type": ["train"] * 14,
-            "resolution": ["daily"] * 14,
+            "date": date,
+            "state_abb": "CA",
+            ".variable": variable,
+            ".value": value,
+            "data_type": "train",
+            "resolution": "daily",
         }
+        for date, observed in zip(dates, observed_ed_visits, strict=True)
+        for variable, value in zip(
+            variables,
+            (observed, other_ed_visits),
+            strict=True,
+        )
     )
 
     result = aggregate_nssp_to_epiweekly(data)
+    week_end_dates = (dt.date(2025, 1, 11), dt.date(2025, 1, 18))
+    weekly_values = ((28, 63), (77, 63))
     expected = pl.DataFrame(
         {
-            "date": [dt.date(2025, 1, 11), dt.date(2025, 1, 18)],
-            "state_abb": ["CA", "CA"],
-            "observed_ed_visits": [28, 77],
-            "other_ed_visits": [63, 63],
-            "data_type": ["train", "train"],
-            "resolution": ["epiweekly", "epiweekly"],
+            "date": date,
+            "state_abb": "CA",
+            ".variable": variable,
+            ".value": value,
+            "data_type": "train",
+            "resolution": "epiweekly",
         }
+        for date, values in zip(week_end_dates, weekly_values, strict=True)
+        for variable, value in zip(variables, values, strict=True)
     )
     assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary

- keep normalized NSSP surveillance data in long form through loading, aggregation, and combined-data serialization
- pivot only at the legacy model-fit JSON boundary and adapt EpiAutoGP to consume the long-form contract
- update synthetic data generation, fixtures, and coverage for the new internal representation
- retain forced single-model integration outputs in model-specific directories and add `just clean-outputs` to remove retained test artifacts

Closes #1253

## Testing

- `uv run pytest -m "not pipeline_e2e and not model_integration" -q` (167 passed, 4 deselected)
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- Fable model integration with mock data
- reduced end-to-end pipeline with mock data
- `just --dry-run test-fable mock CA covid`
- `just --dry-run test-pyrenew mock NY flu`
- `just --dry-run test-epiautogp mock TX rsv`
- `just --dry-run clean-outputs`
- `git diff --check`