### PR TITLE
Align test nowcasts with selected NHSN dates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -25,26 +25,36 @@ e2e data_mode="auto":
       --e2e-force \
       --e2e-data-mode "{{data_mode}}"
 
-# Test Fable for one disease and location with mock or real DataOps data.
+# Test Fable for one disease and location and retain its output.
 test-fable data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_fable_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}"
+      --model-test-disease "{{disease}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/fable-{{disease}}-{{location}}" \
+      --e2e-force
 
-# Test PyRenew for one disease and location with mock or real DataOps data.
+# Test PyRenew for one disease and location and retain its output.
 test-pyrenew data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_pyrenew_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}"
+      --model-test-disease "{{disease}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/pyrenew-{{disease}}-{{location}}" \
+      --e2e-force
 
-# Test EpiAutoGP for one disease and location with mock or real DataOps data.
+# Test EpiAutoGP for one disease and location and retain its output.
 test-epiautogp data_mode="auto" location="CA" disease="covid":
     uv run pytest -s \
       tests/integration/test_epiautogp_forecast.py \
       --e2e-data-mode "{{data_mode}}" \
       --model-test-location "{{location}}" \
-      --model-test-disease "{{disease}}"
+      --model-test-disease "{{disease}}" \
+      --e2e-output-dir "{{e2e_output_dir}}/epiautogp-{{disease}}-{{location}}" \
+      --e2e-force
+
+# Remove all retained end-to-end and single-model test outputs.
+clean-outputs:
+    rm -rf -- "{{e2e_output_dir}}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,10 @@ dagster-config-editor = [
     "rich",
 ]
 test = [
+    "matplotlib>=3.11.1",
     "pytest>=8.3.2",
     "pytest-cov>=5.0.0",
-    "pytest-mpl>=0.17.0"
+    "pytest-mpl>=0.17.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dagster-config-editor = [
     "rich",
 ]
 test = [
-    "matplotlib>=3.11.1",
+    "plotnine>=0.15.3",
     "pytest>=8.3.2",
     "pytest-cov>=5.0.0",
     "pytest-mpl>=0.17.0",

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -54,6 +54,7 @@ HUBVERSE_NOWCAST_DIR_NAME = "hubverse_nowcasts"
 HUBVERSE_N_SAMPLES = 40
 HUBVERSE_LOGNORMAL_SIGMA = 0.05
 HUBVERSE_RANDOM_SEED = 12345
+HUBVERSE_MIN_STABLE_OBSERVATIONS = 2
 
 _SOURCE_DATA_COLS = [
     "date",
@@ -319,24 +320,27 @@ def _make_location_hubverse_nowcasts(
     location: LocationData,
     disease: str,
     disease_index: int,
+    nhsn_observation_dates: Collection[dt.date],
     rng: np.random.Generator,
 ) -> list[dict]:
     """Make noisy Hubverse sample nowcasts for one disease and location."""
-    n_nowcast_dates = len(REPORTING_FRACTIONS) - 1
-    recent_reports = (
-        _make_nhsn(
-            location=location,
-            disease=disease,
-            disease_index=disease_index,
-        )
-        .filter(pl.col("date") < REPORT_DATE)
-        .tail(n_nowcast_dates)
+    selected_reports = _make_nhsn(
+        location=location,
+        disease=disease,
+        disease_index=disease_index,
+    ).filter(pl.col("date").is_in(nhsn_observation_dates))
+    n_nowcast_dates = min(
+        len(REPORTING_FRACTIONS) - 1,
+        selected_reports.height - HUBVERSE_MIN_STABLE_OBSERVATIONS,
     )
-    if recent_reports.height != n_nowcast_dates:
+    if n_nowcast_dates < 1:
         raise ValueError(
-            f"Expected {n_nowcast_dates} NHSN reports for "
-            f"{disease}, {location.abbr}; found {recent_reports.height}"
+            "Expected at least one NHSN nowcast date and "
+            f"{HUBVERSE_MIN_STABLE_OBSERVATIONS} stable observations for "
+            f"{disease}, {location.abbr}; found {selected_reports.height} "
+            "selected reports."
         )
+    recent_reports = selected_reports.tail(n_nowcast_dates)
 
     dates = recent_reports.get_column("date").to_list()
     reports = recent_reports.get_column("value").to_numpy()
@@ -375,6 +379,7 @@ def _make_disease_hubverse_nowcasts(
     locations: list[LocationData],
     disease: str,
     disease_index: int,
+    nhsn_observation_dates: Collection[dt.date],
 ) -> pl.DataFrame:
     """Make noisy Hubverse sample nowcasts for one disease."""
     rng = np.random.default_rng(HUBVERSE_RANDOM_SEED + disease_index)
@@ -385,6 +390,7 @@ def _make_disease_hubverse_nowcasts(
                 location=location,
                 disease=disease,
                 disease_index=disease_index,
+                nhsn_observation_dates=nhsn_observation_dates,
                 rng=rng,
             )
         )
@@ -415,6 +421,8 @@ def _write_disease_hubverse_nowcasts(
 
 def write_hubverse_nowcasts(
     base_dir: Path,
+    *,
+    nhsn_observation_dates: Collection[dt.date],
     locations: list[str] | None = None,
     diseases: list[str] | None = None,
 ) -> None:
@@ -422,8 +430,8 @@ def write_hubverse_nowcasts(
     Write noisy sample nowcasts in the production Hubverse schema.
 
     This reuses `_make_nhsn` to generate the underlying "true" counts for the
-    most recent weeks, then adds fixed-sigma lognormal noise to simulate the
-    nowcast process.
+    most recent selected NHSN observation dates, then adds fixed-sigma
+    lognormal noise to simulate the nowcast process.
     """
     locations = locations or DEFAULT_LOCATIONS
     diseases = diseases or DEFAULT_DISEASES
@@ -438,6 +446,7 @@ def write_hubverse_nowcasts(
             locations=location_data,
             disease=disease,
             disease_index=disease_index,
+            nhsn_observation_dates=nhsn_observation_dates,
         )
         _write_disease_hubverse_nowcasts(
             base_dir=base_dir,

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -392,6 +392,68 @@ def _make_hubverse_nowcast_rows(
     )
 
 
+def _write_hubverse_nowcast_figure(
+    *,
+    nowcasts: pl.DataFrame,
+    nhsn_observations: pl.DataFrame,
+    output_path: Path,
+    disease: str,
+    location: str,
+) -> None:
+    """Plot simulated nowcast trajectories over the selected NHSN reports."""
+    from matplotlib import pyplot as plt
+
+    observations = nhsn_observations.select(
+        pl.col("date").cast(pl.Date),
+        pl.col("value").cast(pl.Float64),
+    ).sort("date")
+    trajectories = nowcasts.sort("output_type_id", "target_end_date").partition_by(
+        "output_type_id", maintain_order=True
+    )
+    mean_nowcast = (
+        nowcasts.group_by("target_end_date")
+        .agg(pl.col("value").mean())
+        .sort("target_end_date")
+    )
+
+    figure, axis = plt.subplots(figsize=(9, 5))
+    for index, trajectory in enumerate(trajectories):
+        axis.plot(
+            trajectory.get_column("target_end_date"),
+            trajectory.get_column("value"),
+            color="tab:blue",
+            alpha=0.12,
+            linewidth=1,
+            label="Simulated nowcast trajectories" if index == 0 else None,
+        )
+    axis.plot(
+        mean_nowcast.get_column("target_end_date"),
+        mean_nowcast.get_column("value"),
+        color="tab:blue",
+        linewidth=2,
+        label="Mean simulated nowcast",
+    )
+    axis.plot(
+        observations.get_column("date"),
+        observations.get_column("value"),
+        color="black",
+        marker="o",
+        linewidth=1.5,
+        label="Selected NHSN observations",
+    )
+    axis.set(
+        title=f"Simulated Hubverse nowcasts: {disease}, {location}",
+        xlabel="Target end date",
+        ylabel="Weekly incident hospital admissions",
+    )
+    axis.grid(alpha=0.2)
+    axis.legend()
+    figure.autofmt_xdate()
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=150)
+    plt.close(figure)
+
+
 def write_hubverse_nowcast(
     base_dir: Path,
     *,
@@ -424,3 +486,10 @@ def write_hubverse_nowcast(
     )
     output_dir.mkdir(parents=True, exist_ok=True)
     nowcasts.write_parquet(output_dir / f"{REPORT_DATE}-CFA-nowcastNHSN.parquet")
+    _write_hubverse_nowcast_figure(
+        nowcasts=nowcasts,
+        nhsn_observations=nhsn_observations,
+        output_path=output_dir / f"{REPORT_DATE}-CFA-nowcastNHSN.png",
+        disease=disease,
+        location=location,
+    )

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -324,7 +324,7 @@ def _make_hubverse_nowcast_rows(
     disease: str,
     nhsn_observations: pl.DataFrame,
     rng: np.random.Generator,
-) -> list[dict]:
+) -> pl.DataFrame:
     """Make noisy Hubverse sample nowcasts for one disease and location."""
     selected_reports = nhsn_observations.select(
         pl.col("date").cast(pl.Date),
@@ -371,20 +371,25 @@ def _make_hubverse_nowcast_rows(
     samples = expected_final_counts * noise
     location_id = location.lower()
 
-    return [
-        {
-            "origin_date": REPORT_DATE,
-            "target_end_date": target_end_date,
-            "horizon": horizon,
-            "target": HUBVERSE_TARGETS[disease],
-            "location": location_id,
-            "output_type": "sample",
-            "output_type_id": f"{disease}_{location_id}_{sample_index}",
-            "value": value,
-        }
-        for sample_index, trajectory in enumerate(samples, start=1)
-        for target_end_date, horizon, value in zip(dates, horizons, trajectory)
-    ]
+    return pl.DataFrame(
+        [
+            {
+                "origin_date": REPORT_DATE,
+                "target_end_date": target_end_date,
+                "horizon": horizon,
+                "target": HUBVERSE_TARGETS[disease],
+                "location": location_id,
+                "output_type": "sample",
+                "output_type_id": f"{disease}_{location_id}_{sample_index}",
+                "value": value,
+            }
+            for sample_index, trajectory in enumerate(samples, start=1)
+            for target_end_date, horizon, value in zip(dates, horizons, trajectory)
+        ]
+    ).with_columns(
+        pl.col("horizon").cast(pl.Int32),
+        pl.col("value").cast(pl.Float64),
+    )
 
 
 def write_hubverse_nowcast(
@@ -404,16 +409,11 @@ def write_hubverse_nowcast(
     if disease not in HUBVERSE_TARGETS:
         raise ValueError(f"No Hubverse target mapping for {disease!r}")
     disease_index = sorted(HUBVERSE_TARGETS).index(disease)
-    nowcasts = pl.DataFrame(
-        _make_hubverse_nowcast_rows(
-            location=location,
-            disease=disease,
-            nhsn_observations=nhsn_observations,
-            rng=np.random.default_rng(HUBVERSE_RANDOM_SEED + disease_index),
-        )
-    ).with_columns(
-        pl.col("horizon").cast(pl.Int32),
-        pl.col("value").cast(pl.Float64),
+    nowcasts = _make_hubverse_nowcast_rows(
+        location=location,
+        disease=disease,
+        nhsn_observations=nhsn_observations,
+        rng=np.random.default_rng(HUBVERSE_RANDOM_SEED + disease_index),
     )
     output_dir = (
         base_dir

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -56,7 +56,7 @@ HUBVERSE_LOGNORMAL_SIGMA = 0.01
 HUBVERSE_RANDOM_SEED = 12345
 HUBVERSE_MIN_STABLE_OBSERVATIONS = 2
 HUBVERSE_MAX_NOWCAST_DATES = 4
-HUBVERSE_MIN_REVISION = 0.05
+HUBVERSE_MIN_REVISION = 0.01
 HUBVERSE_MAX_REVISION = 0.10
 
 _SOURCE_DATA_COLS = [
@@ -464,7 +464,7 @@ def write_hubverse_nowcast(
     """
     Write one noisy sample nowcast artifact in the production Hubverse schema.
 
-    The expected nowcast is a 5--10% upward revision of each selected NHSN
+    The expected nowcast is a 1--10% upward revision of each selected NHSN
     report, with larger revisions for more recent dates. Fixed-sigma lognormal
     noise simulates uncertainty around those expectations.
     """

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -52,9 +52,12 @@ REPORTING_DELAY_PMF = np.diff(np.insert(REPORTING_FRACTIONS, 0, 0.0))
 
 HUBVERSE_NOWCAST_DIR_NAME = "hubverse_nowcasts"
 HUBVERSE_N_SAMPLES = 40
-HUBVERSE_LOGNORMAL_SIGMA = 0.05
+HUBVERSE_LOGNORMAL_SIGMA = 0.01
 HUBVERSE_RANDOM_SEED = 12345
 HUBVERSE_MIN_STABLE_OBSERVATIONS = 2
+HUBVERSE_MAX_NOWCAST_DATES = 4
+HUBVERSE_MIN_REVISION = 0.05
+HUBVERSE_MAX_REVISION = 0.10
 
 _SOURCE_DATA_COLS = [
     "date",
@@ -319,18 +322,24 @@ def _make_location_hubverse_nowcasts(
     *,
     location: LocationData,
     disease: str,
-    disease_index: int,
-    nhsn_observation_dates: Collection[dt.date],
+    nhsn_observations: pl.DataFrame,
     rng: np.random.Generator,
 ) -> list[dict]:
     """Make noisy Hubverse sample nowcasts for one disease and location."""
-    selected_reports = _make_nhsn(
-        location=location,
-        disease=disease,
-        disease_index=disease_index,
-    ).filter(pl.col("date").is_in(nhsn_observation_dates))
+    selected_reports = nhsn_observations.select(
+        pl.col("date").cast(pl.Date),
+        pl.col("value").cast(pl.Float64),
+    ).sort("date")
+    if selected_reports.select(
+        (
+            pl.col("value").is_null()
+            | (~pl.col("value").is_finite())
+            | (pl.col("value") < 0)
+        ).any()
+    ).item():
+        raise ValueError("Selected NHSN reports must be finite and non-negative.")
     n_nowcast_dates = min(
-        len(REPORTING_FRACTIONS) - 1,
+        HUBVERSE_MAX_NOWCAST_DATES,
         selected_reports.height - HUBVERSE_MIN_STABLE_OBSERVATIONS,
     )
     if n_nowcast_dates < 1:
@@ -348,13 +357,21 @@ def _make_location_hubverse_nowcasts(
         (target_end_date - REPORT_DATE).days // DAYS_PER_WEEK
         for target_end_date in dates
     ]
-    fractions = np.array([REPORTING_FRACTIONS[-horizon - 1] for horizon in horizons])
-    expected_final_counts = reports / fractions
-    log_means = np.log(expected_final_counts) - HUBVERSE_LOGNORMAL_SIGMA**2 / 2
-    samples = rng.lognormal(
+    revision_rates = np.linspace(
+        HUBVERSE_MIN_REVISION,
+        HUBVERSE_MAX_REVISION,
+        n_nowcast_dates,
+    )
+    expected_final_counts = reports * (1 + revision_rates)
+    samples = np.zeros((HUBVERSE_N_SAMPLES, n_nowcast_dates))
+    positive_counts = expected_final_counts > 0
+    log_means = (
+        np.log(expected_final_counts[positive_counts]) - HUBVERSE_LOGNORMAL_SIGMA**2 / 2
+    )
+    samples[:, positive_counts] = rng.lognormal(
         mean=log_means,
         sigma=HUBVERSE_LOGNORMAL_SIGMA,
-        size=(HUBVERSE_N_SAMPLES, n_nowcast_dates),
+        size=(HUBVERSE_N_SAMPLES, positive_counts.sum()),
     )
     disease_id = disease
 
@@ -379,7 +396,7 @@ def _make_disease_hubverse_nowcasts(
     locations: list[LocationData],
     disease: str,
     disease_index: int,
-    nhsn_observation_dates: Collection[dt.date],
+    nhsn_observations: pl.DataFrame,
 ) -> pl.DataFrame:
     """Make noisy Hubverse sample nowcasts for one disease."""
     rng = np.random.default_rng(HUBVERSE_RANDOM_SEED + disease_index)
@@ -389,8 +406,7 @@ def _make_disease_hubverse_nowcasts(
             _make_location_hubverse_nowcasts(
                 location=location,
                 disease=disease,
-                disease_index=disease_index,
-                nhsn_observation_dates=nhsn_observation_dates,
+                nhsn_observations=nhsn_observations,
                 rng=rng,
             )
         )
@@ -422,16 +438,16 @@ def _write_disease_hubverse_nowcasts(
 def write_hubverse_nowcasts(
     base_dir: Path,
     *,
-    nhsn_observation_dates: Collection[dt.date],
+    nhsn_observations: pl.DataFrame,
     locations: list[str] | None = None,
     diseases: list[str] | None = None,
 ) -> None:
     """
     Write noisy sample nowcasts in the production Hubverse schema.
 
-    This reuses `_make_nhsn` to generate the underlying "true" counts for the
-    most recent selected NHSN observation dates, then adds fixed-sigma
-    lognormal noise to simulate the nowcast process.
+    The expected nowcast is a 5--10% upward revision of each selected NHSN
+    report, with larger revisions for more recent dates. Fixed-sigma lognormal
+    noise simulates uncertainty around those expectations.
     """
     locations = locations or DEFAULT_LOCATIONS
     diseases = diseases or DEFAULT_DISEASES
@@ -446,7 +462,7 @@ def write_hubverse_nowcasts(
             locations=location_data,
             disease=disease,
             disease_index=disease_index,
-            nhsn_observation_dates=nhsn_observation_dates,
+            nhsn_observations=nhsn_observations,
         )
         _write_disease_hubverse_nowcasts(
             base_dir=base_dir,

--- a/src/cfa/stf/routine/data/generate_test_data.py
+++ b/src/cfa/stf/routine/data/generate_test_data.py
@@ -318,9 +318,9 @@ def make_surveillance_inputs(
     )
 
 
-def _make_location_hubverse_nowcasts(
+def _make_hubverse_nowcast_rows(
     *,
-    location: LocationData,
+    location: str,
     disease: str,
     nhsn_observations: pl.DataFrame,
     rng: np.random.Generator,
@@ -346,7 +346,7 @@ def _make_location_hubverse_nowcasts(
         raise ValueError(
             "Expected at least one NHSN nowcast date and "
             f"{HUBVERSE_MIN_STABLE_OBSERVATIONS} stable observations for "
-            f"{disease}, {location.abbr}; found {selected_reports.height} "
+            f"{disease}, {location}; found {selected_reports.height} "
             "selected reports."
         )
     recent_reports = selected_reports.tail(n_nowcast_dates)
@@ -363,17 +363,13 @@ def _make_location_hubverse_nowcasts(
         n_nowcast_dates,
     )
     expected_final_counts = reports * (1 + revision_rates)
-    samples = np.zeros((HUBVERSE_N_SAMPLES, n_nowcast_dates))
-    positive_counts = expected_final_counts > 0
-    log_means = (
-        np.log(expected_final_counts[positive_counts]) - HUBVERSE_LOGNORMAL_SIGMA**2 / 2
-    )
-    samples[:, positive_counts] = rng.lognormal(
-        mean=log_means,
+    noise = rng.lognormal(
+        mean=-(HUBVERSE_LOGNORMAL_SIGMA**2) / 2,
         sigma=HUBVERSE_LOGNORMAL_SIGMA,
-        size=(HUBVERSE_N_SAMPLES, positive_counts.sum()),
+        size=(HUBVERSE_N_SAMPLES, n_nowcast_dates),
     )
-    disease_id = disease
+    samples = expected_final_counts * noise
+    location_id = location.lower()
 
     return [
         {
@@ -381,9 +377,9 @@ def _make_location_hubverse_nowcasts(
             "target_end_date": target_end_date,
             "horizon": horizon,
             "target": HUBVERSE_TARGETS[disease],
-            "location": location.abbr.lower(),
+            "location": location_id,
             "output_type": "sample",
-            "output_type_id": (f"{disease_id}_{location.abbr.lower()}_{sample_index}"),
+            "output_type_id": f"{disease}_{location_id}_{sample_index}",
             "value": value,
         }
         for sample_index, trajectory in enumerate(samples, start=1)
@@ -391,39 +387,34 @@ def _make_location_hubverse_nowcasts(
     ]
 
 
-def _make_disease_hubverse_nowcasts(
+def write_hubverse_nowcast(
+    base_dir: Path,
     *,
-    locations: list[LocationData],
     disease: str,
-    disease_index: int,
+    location: str,
     nhsn_observations: pl.DataFrame,
-) -> pl.DataFrame:
-    """Make noisy Hubverse sample nowcasts for one disease."""
-    rng = np.random.default_rng(HUBVERSE_RANDOM_SEED + disease_index)
-    rows = []
-    for location in locations:
-        rows.extend(
-            _make_location_hubverse_nowcasts(
-                location=location,
-                disease=disease,
-                nhsn_observations=nhsn_observations,
-                rng=rng,
-            )
-        )
+) -> None:
+    """
+    Write one noisy sample nowcast artifact in the production Hubverse schema.
 
-    return pl.DataFrame(rows).with_columns(
+    The expected nowcast is a 5--10% upward revision of each selected NHSN
+    report, with larger revisions for more recent dates. Fixed-sigma lognormal
+    noise simulates uncertainty around those expectations.
+    """
+    if disease not in HUBVERSE_TARGETS:
+        raise ValueError(f"No Hubverse target mapping for {disease!r}")
+    disease_index = sorted(HUBVERSE_TARGETS).index(disease)
+    nowcasts = pl.DataFrame(
+        _make_hubverse_nowcast_rows(
+            location=location,
+            disease=disease,
+            nhsn_observations=nhsn_observations,
+            rng=np.random.default_rng(HUBVERSE_RANDOM_SEED + disease_index),
+        )
+    ).with_columns(
         pl.col("horizon").cast(pl.Int32),
         pl.col("value").cast(pl.Float64),
     )
-
-
-def _write_disease_hubverse_nowcasts(
-    *,
-    base_dir: Path,
-    disease: str,
-    nowcasts: pl.DataFrame,
-) -> None:
-    """Write one disease's Hubverse nowcasts to its production-style path."""
     output_dir = (
         base_dir
         / "private_data"
@@ -433,39 +424,3 @@ def _write_disease_hubverse_nowcasts(
     )
     output_dir.mkdir(parents=True, exist_ok=True)
     nowcasts.write_parquet(output_dir / f"{REPORT_DATE}-CFA-nowcastNHSN.parquet")
-
-
-def write_hubverse_nowcasts(
-    base_dir: Path,
-    *,
-    nhsn_observations: pl.DataFrame,
-    locations: list[str] | None = None,
-    diseases: list[str] | None = None,
-) -> None:
-    """
-    Write noisy sample nowcasts in the production Hubverse schema.
-
-    The expected nowcast is a 5--10% upward revision of each selected NHSN
-    report, with larger revisions for more recent dates. Fixed-sigma lognormal
-    noise simulates uncertainty around those expectations.
-    """
-    locations = locations or DEFAULT_LOCATIONS
-    diseases = diseases or DEFAULT_DISEASES
-    all_diseases = sorted(set(DEFAULT_DISEASES + diseases))
-    location_data = _location_data(locations)
-
-    for disease in diseases:
-        if disease not in HUBVERSE_TARGETS:
-            raise ValueError(f"No Hubverse target mapping for {disease!r}")
-        disease_index = all_diseases.index(disease)
-        nowcasts = _make_disease_hubverse_nowcasts(
-            locations=location_data,
-            disease=disease,
-            disease_index=disease_index,
-            nhsn_observations=nhsn_observations,
-        )
-        _write_disease_hubverse_nowcasts(
-            base_dir=base_dir,
-            disease=disease,
-            nowcasts=nowcasts,
-        )

--- a/tests/data/test_generate_test_data.py
+++ b/tests/data/test_generate_test_data.py
@@ -62,14 +62,13 @@ def test_hubverse_nowcasts_use_selected_nhsn_observations(n_selected, n_nowcast)
         {"date": selected_dates, "value": [100.0] * n_selected}
     )
 
-    rows = _make_hubverse_nowcast_rows(
+    nowcasts = _make_hubverse_nowcast_rows(
         location="CA",
         disease="covid",
         nhsn_observations=selected_observations,
         rng=np.random.default_rng(12345),
     )
 
-    nowcasts = pl.DataFrame(rows)
     assert (
         nowcasts.get_column("target_end_date").unique().sort().to_list()
         == (selected_dates[-n_nowcast:])

--- a/tests/data/test_generate_test_data.py
+++ b/tests/data/test_generate_test_data.py
@@ -6,10 +6,16 @@ import pytest
 
 from cfa.stf.routine.data.generate_test_data import (
     FIRST_OBS_DATE,
+    HUBVERSE_NOWCAST_DIR_NAME,
     LAST_OBS_DATE,
+    REPORT_DATE,
     LocationData,
     _make_hubverse_nowcast_rows,
     _make_nssp,
+    write_hubverse_nowcast,
+)
+from cfa.stf.routine.data.hubverse_nowcast import (
+    HUBVERSE_MODEL_OUTPUT_SUBDIR,
 )
 
 
@@ -82,3 +88,32 @@ def test_hubverse_nowcasts_use_selected_nhsn_observations(n_selected, n_nowcast)
     )
     expected_means = np.linspace(105.0, 110.0, n_nowcast)
     np.testing.assert_allclose(mean_nowcasts, expected_means, rtol=0.01)
+
+
+def test_write_hubverse_nowcast_writes_data_and_figure(tmp_path):
+    observations = pl.DataFrame(
+        {
+            "date": [
+                dt.date(2026, 7, 4) + dt.timedelta(weeks=index) for index in range(6)
+            ],
+            "value": [100.0] * 6,
+        }
+    )
+
+    write_hubverse_nowcast(
+        tmp_path,
+        disease="covid",
+        location="CA",
+        nhsn_observations=observations,
+    )
+
+    output_dir = (
+        tmp_path
+        / "private_data"
+        / HUBVERSE_NOWCAST_DIR_NAME
+        / "covid"
+        / HUBVERSE_MODEL_OUTPUT_SUBDIR
+    )
+    artifact_stem = f"{REPORT_DATE}-CFA-nowcastNHSN"
+    assert (output_dir / f"{artifact_stem}.parquet").is_file()
+    assert (output_dir / f"{artifact_stem}.png").is_file()

--- a/tests/data/test_generate_test_data.py
+++ b/tests/data/test_generate_test_data.py
@@ -1,16 +1,15 @@
+import datetime as dt
+
 import numpy as np
 import polars as pl
 import pytest
 
 from cfa.stf.routine.data.generate_test_data import (
     FIRST_OBS_DATE,
-    HUBVERSE_MAX_REVISION,
-    HUBVERSE_MIN_REVISION,
     LAST_OBS_DATE,
     LocationData,
-    _make_location_hubverse_nowcasts,
+    _make_hubverse_nowcast_rows,
     _make_nssp,
-    _weekending_dates,
 )
 
 
@@ -54,16 +53,17 @@ def test_make_nssp_returns_location_level_cfa_stf_data_schema():
 
 
 @pytest.mark.parametrize(("n_selected", "n_nowcast"), [(5, 3), (6, 4)])
-def test_hubverse_nowcast_dates_come_from_selected_nhsn_observations(
-    n_selected, n_nowcast
-):
-    selected_dates = _weekending_dates()[-(n_selected + 1) : -1]
+def test_hubverse_nowcasts_use_selected_nhsn_observations(n_selected, n_nowcast):
+    first_date = dt.date(2026, 7, 4)
+    selected_dates = [
+        first_date + dt.timedelta(weeks=index) for index in range(n_selected)
+    ]
     selected_observations = pl.DataFrame(
         {"date": selected_dates, "value": [100.0] * n_selected}
     )
 
-    rows = _make_location_hubverse_nowcasts(
-        location=LocationData(abbr="CA", population=100_000),
+    rows = _make_hubverse_nowcast_rows(
+        location="CA",
         disease="covid",
         nhsn_observations=selected_observations,
         rng=np.random.default_rng(12345),
@@ -81,12 +81,5 @@ def test_hubverse_nowcast_dates_come_from_selected_nhsn_observations(
         .get_column("value")
         .to_numpy()
     )
-    expected_means = 100 * (
-        1
-        + np.linspace(
-            HUBVERSE_MIN_REVISION,
-            HUBVERSE_MAX_REVISION,
-            n_nowcast,
-        )
-    )
+    expected_means = np.linspace(105.0, 110.0, n_nowcast)
     np.testing.assert_allclose(mean_nowcasts, expected_means, rtol=0.01)

--- a/tests/data/test_generate_test_data.py
+++ b/tests/data/test_generate_test_data.py
@@ -1,10 +1,14 @@
+import numpy as np
 import polars as pl
+import pytest
 
 from cfa.stf.routine.data.generate_test_data import (
     FIRST_OBS_DATE,
     LAST_OBS_DATE,
     LocationData,
+    _make_location_hubverse_nowcasts,
     _make_nssp,
+    _weekending_dates,
 )
 
 
@@ -44,4 +48,23 @@ def test_make_nssp_returns_location_level_cfa_stf_data_schema():
         .select(pl.col("total") > pl.col("disease_sum"))
         .to_series()
         .all()
+    )
+
+
+@pytest.mark.parametrize(("n_selected", "n_nowcast"), [(5, 3), (6, 4)])
+def test_hubverse_nowcast_dates_come_from_selected_nhsn_observations(
+    n_selected, n_nowcast
+):
+    selected_dates = _weekending_dates()[-(n_selected + 1) : -1]
+
+    rows = _make_location_hubverse_nowcasts(
+        location=LocationData(abbr="CA", population=100_000),
+        disease="covid",
+        disease_index=0,
+        nhsn_observation_dates=selected_dates,
+        rng=np.random.default_rng(12345),
+    )
+
+    assert (
+        sorted({row["target_end_date"] for row in rows}) == selected_dates[-n_nowcast:]
     )

--- a/tests/data/test_generate_test_data.py
+++ b/tests/data/test_generate_test_data.py
@@ -3,8 +3,7 @@ import datetime as dt
 import numpy as np
 import polars as pl
 import pytest
-
-from cfa.stf.routine.data.generate_test_data import (
+from tests.integration.generate_test_data import (
     FIRST_OBS_DATE,
     HUBVERSE_NOWCAST_DIR_NAME,
     LAST_OBS_DATE,
@@ -14,6 +13,7 @@ from cfa.stf.routine.data.generate_test_data import (
     _make_nssp,
     write_hubverse_nowcast,
 )
+
 from cfa.stf.routine.data.hubverse_nowcast import (
     HUBVERSE_MODEL_OUTPUT_SUBDIR,
 )

--- a/tests/data/test_generate_test_data.py
+++ b/tests/data/test_generate_test_data.py
@@ -4,6 +4,8 @@ import pytest
 
 from cfa.stf.routine.data.generate_test_data import (
     FIRST_OBS_DATE,
+    HUBVERSE_MAX_REVISION,
+    HUBVERSE_MIN_REVISION,
     LAST_OBS_DATE,
     LocationData,
     _make_location_hubverse_nowcasts,
@@ -56,15 +58,35 @@ def test_hubverse_nowcast_dates_come_from_selected_nhsn_observations(
     n_selected, n_nowcast
 ):
     selected_dates = _weekending_dates()[-(n_selected + 1) : -1]
+    selected_observations = pl.DataFrame(
+        {"date": selected_dates, "value": [100.0] * n_selected}
+    )
 
     rows = _make_location_hubverse_nowcasts(
         location=LocationData(abbr="CA", population=100_000),
         disease="covid",
-        disease_index=0,
-        nhsn_observation_dates=selected_dates,
+        nhsn_observations=selected_observations,
         rng=np.random.default_rng(12345),
     )
 
+    nowcasts = pl.DataFrame(rows)
     assert (
-        sorted({row["target_end_date"] for row in rows}) == selected_dates[-n_nowcast:]
+        nowcasts.get_column("target_end_date").unique().sort().to_list()
+        == (selected_dates[-n_nowcast:])
     )
+    mean_nowcasts = (
+        nowcasts.group_by("target_end_date")
+        .agg(pl.col("value").mean())
+        .sort("target_end_date")
+        .get_column("value")
+        .to_numpy()
+    )
+    expected_means = 100 * (
+        1
+        + np.linspace(
+            HUBVERSE_MIN_REVISION,
+            HUBVERSE_MAX_REVISION,
+            n_nowcast,
+        )
+    )
+    np.testing.assert_allclose(mean_nowcasts, expected_means, rtol=0.01)

--- a/tests/data/test_generate_test_data.py
+++ b/tests/data/test_generate_test_data.py
@@ -86,7 +86,7 @@ def test_hubverse_nowcasts_use_selected_nhsn_observations(n_selected, n_nowcast)
         .get_column("value")
         .to_numpy()
     )
-    expected_means = np.linspace(105.0, 110.0, n_nowcast)
+    expected_means = np.linspace(101.0, 110.0, n_nowcast)
     np.testing.assert_allclose(mean_nowcasts, expected_means, rtol=0.01)
 
 

--- a/tests/integration/generate_test_data.py
+++ b/tests/integration/generate_test_data.py
@@ -9,6 +9,7 @@ import numpy as np
 import polars as pl
 import polars.selectors as cs
 from cfa.stf.forecasttools import get_us_loc_pop_tbl
+from matplotlib import pyplot as plt
 
 from cfa.stf.routine.data.data_access import (
     DataFreshness,
@@ -401,8 +402,6 @@ def _write_hubverse_nowcast_figure(
     location: str,
 ) -> None:
     """Plot simulated nowcast trajectories over the selected NHSN reports."""
-    from matplotlib import pyplot as plt
-
     observations = nhsn_observations.select(
         pl.col("date").cast(pl.Date),
         pl.col("value").cast(pl.Float64),

--- a/tests/integration/generate_test_data.py
+++ b/tests/integration/generate_test_data.py
@@ -9,7 +9,17 @@ import numpy as np
 import polars as pl
 import polars.selectors as cs
 from cfa.stf.forecasttools import get_us_loc_pop_tbl
-from matplotlib import pyplot as plt
+from plotnine import (
+    aes,
+    element_text,
+    geom_line,
+    geom_point,
+    ggplot,
+    labs,
+    scale_color_manual,
+    theme,
+    theme_minimal,
+)
 
 from cfa.stf.routine.data.data_access import (
     DataFreshness,
@@ -402,55 +412,72 @@ def _write_hubverse_nowcast_figure(
     location: str,
 ) -> None:
     """Plot simulated nowcast trajectories over the selected NHSN reports."""
+    trajectory_label = "Simulated nowcast trajectories"
+    mean_label = "Mean simulated nowcast"
+    observation_label = "Selected NHSN observations"
     observations = nhsn_observations.select(
-        pl.col("date").cast(pl.Date),
+        pl.col("date").cast(pl.Date).alias("target_end_date"),
         pl.col("value").cast(pl.Float64),
-    ).sort("date")
-    trajectories = nowcasts.sort("output_type_id", "target_end_date").partition_by(
-        "output_type_id", maintain_order=True
-    )
+        pl.lit(observation_label).alias("series"),
+    ).sort("target_end_date")
+    trajectories = nowcasts.with_columns(pl.lit(trajectory_label).alias("series"))
     mean_nowcast = (
         nowcasts.group_by("target_end_date")
         .agg(pl.col("value").mean())
         .sort("target_end_date")
+        .with_columns(pl.lit(mean_label).alias("series"))
     )
 
-    figure, axis = plt.subplots(figsize=(9, 5))
-    for index, trajectory in enumerate(trajectories):
-        axis.plot(
-            trajectory.get_column("target_end_date"),
-            trajectory.get_column("value"),
-            color="tab:blue",
+    plot = (
+        ggplot()
+        + geom_line(
+            trajectories,
+            aes(
+                x="target_end_date",
+                y="value",
+                group="output_type_id",
+                color="series",
+            ),
             alpha=0.12,
-            linewidth=1,
-            label="Simulated nowcast trajectories" if index == 0 else None,
+            size=0.5,
         )
-    axis.plot(
-        mean_nowcast.get_column("target_end_date"),
-        mean_nowcast.get_column("value"),
-        color="tab:blue",
-        linewidth=2,
-        label="Mean simulated nowcast",
+        + geom_line(
+            mean_nowcast,
+            aes(x="target_end_date", y="value", color="series"),
+            size=1.2,
+        )
+        + geom_line(
+            observations,
+            aes(x="target_end_date", y="value", color="series"),
+            size=0.8,
+        )
+        + geom_point(
+            observations,
+            aes(x="target_end_date", y="value", color="series"),
+            size=2,
+        )
+        + scale_color_manual(
+            name=None,
+            breaks=[trajectory_label, mean_label, observation_label],
+            values={
+                trajectory_label: "tab:blue",
+                mean_label: "tab:blue",
+                observation_label: "black",
+            },
+        )
+        + labs(
+            title=f"Simulated Hubverse nowcasts: {disease}, {location}",
+            x="Target end date",
+            y="Weekly incident hospital admissions",
+        )
+        + theme_minimal()
+        + theme(
+            axis_text_x=element_text(rotation=30, ha="right"),
+            figure_size=(9, 5),
+            legend_position="bottom",
+        )
     )
-    axis.plot(
-        observations.get_column("date"),
-        observations.get_column("value"),
-        color="black",
-        marker="o",
-        linewidth=1.5,
-        label="Selected NHSN observations",
-    )
-    axis.set(
-        title=f"Simulated Hubverse nowcasts: {disease}, {location}",
-        xlabel="Target end date",
-        ylabel="Weekly incident hospital admissions",
-    )
-    axis.grid(alpha=0.2)
-    axis.legend()
-    figure.autofmt_xdate()
-    figure.tight_layout()
-    figure.savefig(output_path, dpi=150)
-    plt.close(figure)
+    plot.save(filename=output_path, dpi=150, verbose=False)
 
 
 def write_hubverse_nowcast(

--- a/tests/integration/model_test_utils.py
+++ b/tests/integration/model_test_utils.py
@@ -1,4 +1,3 @@
-import datetime as dt
 import logging
 from dataclasses import replace
 from math import isclose
@@ -125,11 +124,11 @@ def configure_data_mode(request, monkeypatch) -> str:
     return data_mode
 
 
-def selected_nhsn_observation_dates(
+def selected_nhsn_observations(
     disease: str,
     location: str,
-) -> list[dt.date]:
-    """Load the NHSN training dates selected for a model integration run."""
+) -> pl.DataFrame:
+    """Load the NHSN training observations selected for an integration run."""
     logger = logging.getLogger(__name__)
     first_training_date, last_training_date = calculate_training_dates(
         REPORT_DATE,
@@ -152,11 +151,13 @@ def selected_nhsn_observation_dates(
             "Expected selected surveillance inputs to contain NHSN data"
         )
     return (
-        surveillance.nhsn.data.filter(pl.col("data_type") == "train")
-        .get_column("date")
-        .unique()
-        .sort()
-        .to_list()
+        surveillance.nhsn.data.filter(
+            (pl.col("data_type") == "train")
+            & pl.col("value").is_not_null()
+            & pl.col("value").is_finite()
+        )
+        .select("date", "value")
+        .sort("date")
     )
 
 

--- a/tests/integration/model_test_utils.py
+++ b/tests/integration/model_test_utils.py
@@ -1,7 +1,10 @@
+import datetime as dt
+import logging
 from dataclasses import replace
 from math import isclose
 from pathlib import Path
 
+import polars as pl
 from pyrenew_multisignal.hew.utils import flags_from_hew_letters
 
 from cfa.stf.routine import forecast_pipeline as forecast_pipeline_module
@@ -17,6 +20,7 @@ from cfa.stf.routine.fable import forecast_fable as fable_module
 from cfa.stf.routine.pyrenew_hew import forecast_pyrenew as pyrenew_module
 from cfa.stf.routine.pyrenew_hew import model_inputs as pyrenew_inputs_module
 from cfa.stf.routine.utils.data_utils import aggregate_nssp_to_epiweekly
+from cfa.stf.routine.utils.date_utils import calculate_training_dates
 
 FORECAST_DIR_NAME = f"{REPORT_DATE.isoformat()}_forecasts"
 N_TRAINING_DAYS = 42
@@ -119,6 +123,41 @@ def configure_data_mode(request, monkeypatch) -> str:
     if data_mode == MOCK_DATA_MODE:
         patch_dataops_with_mock_data(monkeypatch)
     return data_mode
+
+
+def selected_nhsn_observation_dates(
+    disease: str,
+    location: str,
+) -> list[dt.date]:
+    """Load the NHSN training dates selected for a model integration run."""
+    logger = logging.getLogger(__name__)
+    first_training_date, last_training_date = calculate_training_dates(
+        REPORT_DATE,
+        N_TRAINING_DAYS,
+        EXCLUDE_LAST_N_DAYS,
+        logger,
+    )
+    surveillance = forecast_pipeline_module.load_surveillance_inputs(
+        disease=disease,
+        loc_abb=location,
+        run_date=REPORT_DATE,
+        first_training_date=first_training_date,
+        last_training_date=last_training_date,
+        sources={"nhsn"},
+        ed_visit_input_resolution="epiweekly",
+        logger=logger,
+    )
+    if surveillance.nhsn is None:
+        raise AssertionError(
+            "Expected selected surveillance inputs to contain NHSN data"
+        )
+    return (
+        surveillance.nhsn.data.filter(pl.col("data_type") == "train")
+        .get_column("date")
+        .unique()
+        .sort()
+        .to_list()
+    )
 
 
 def run_fable(

--- a/tests/integration/model_test_utils.py
+++ b/tests/integration/model_test_utils.py
@@ -5,15 +5,15 @@ from pathlib import Path
 
 import polars as pl
 from pyrenew_multisignal.hew.utils import flags_from_hew_letters
-
-from cfa.stf.routine import forecast_pipeline as forecast_pipeline_module
-from cfa.stf.routine._paths import PRODUCTION_PRIORS
-from cfa.stf.routine.data.data_access import DataResolution
-from cfa.stf.routine.data.generate_test_data import (
+from tests.integration.generate_test_data import (
     REPORT_DATE,
     REPORTING_DELAY_PMF,
     make_surveillance_inputs,
 )
+
+from cfa.stf.routine import forecast_pipeline as forecast_pipeline_module
+from cfa.stf.routine._paths import PRODUCTION_PRIORS
+from cfa.stf.routine.data.data_access import DataResolution
 from cfa.stf.routine.epiautogp import forecast_epiautogp as epiautogp_module
 from cfa.stf.routine.fable import forecast_fable as fable_module
 from cfa.stf.routine.pyrenew_hew import forecast_pyrenew as pyrenew_module

--- a/tests/integration/test_epiautogp_forecast.py
+++ b/tests/integration/test_epiautogp_forecast.py
@@ -1,15 +1,14 @@
 import pytest
+from tests.integration.generate_test_data import (
+    HUBVERSE_N_SAMPLES,
+    HUBVERSE_NOWCAST_DIR_NAME,
+    write_hubverse_nowcast,
+)
 from tests.integration.model_test_utils import (
     assert_model_outputs,
     configure_data_mode,
     run_epiautogp,
     selected_nhsn_observations,
-)
-
-from cfa.stf.routine.data.generate_test_data import (
-    HUBVERSE_N_SAMPLES,
-    HUBVERSE_NOWCAST_DIR_NAME,
-    write_hubverse_nowcast,
 )
 
 EPIAUTOGP_CONFIGURATIONS = (

--- a/tests/integration/test_epiautogp_forecast.py
+++ b/tests/integration/test_epiautogp_forecast.py
@@ -21,12 +21,18 @@ EPIAUTOGP_CONFIGURATIONS = (
         "epiautogp_nhsn_epiweekly",
     ),
     ("nssp", "epiweekly", "pct", "none", "epiautogp_nssp_epiweekly_pct"),
-    ("nssp", "daily", "observed", "none", "epiautogp_nssp_daily"),
+    (
+        "nssp",
+        "daily",
+        "observed",
+        "reporting-delay",
+        "epiautogp_nssp_daily",
+    ),
     (
         "nssp",
         "daily",
         "other",
-        "reporting-delay",
+        "none",
         "epiautogp_nssp_daily_other",
     ),
 )

--- a/tests/integration/test_epiautogp_forecast.py
+++ b/tests/integration/test_epiautogp_forecast.py
@@ -3,6 +3,7 @@ from tests.integration.model_test_utils import (
     assert_model_outputs,
     configure_data_mode,
     run_epiautogp,
+    selected_nhsn_observation_dates,
 )
 
 from cfa.stf.routine.data.generate_test_data import (
@@ -38,6 +39,7 @@ def test_epiautogp_forecast(pipeline_workspace, monkeypatch, request):
     configure_data_mode(request, monkeypatch)
     write_hubverse_nowcasts(
         pipeline_workspace,
+        nhsn_observation_dates=selected_nhsn_observation_dates(disease, location),
         locations=[location],
         diseases=[disease],
     )

--- a/tests/integration/test_epiautogp_forecast.py
+++ b/tests/integration/test_epiautogp_forecast.py
@@ -3,7 +3,7 @@ from tests.integration.model_test_utils import (
     assert_model_outputs,
     configure_data_mode,
     run_epiautogp,
-    selected_nhsn_observation_dates,
+    selected_nhsn_observations,
 )
 
 from cfa.stf.routine.data.generate_test_data import (
@@ -39,7 +39,7 @@ def test_epiautogp_forecast(pipeline_workspace, monkeypatch, request):
     configure_data_mode(request, monkeypatch)
     write_hubverse_nowcasts(
         pipeline_workspace,
-        nhsn_observation_dates=selected_nhsn_observation_dates(disease, location),
+        nhsn_observations=selected_nhsn_observations(disease, location),
         locations=[location],
         diseases=[disease],
     )

--- a/tests/integration/test_epiautogp_forecast.py
+++ b/tests/integration/test_epiautogp_forecast.py
@@ -9,7 +9,7 @@ from tests.integration.model_test_utils import (
 from cfa.stf.routine.data.generate_test_data import (
     HUBVERSE_N_SAMPLES,
     HUBVERSE_NOWCAST_DIR_NAME,
-    write_hubverse_nowcasts,
+    write_hubverse_nowcast,
 )
 
 EPIAUTOGP_CONFIGURATIONS = (
@@ -43,11 +43,11 @@ def test_epiautogp_forecast(pipeline_workspace, monkeypatch, request):
     disease = request.config.getoption("--model-test-disease")
     location = request.config.getoption("--model-test-location")
     configure_data_mode(request, monkeypatch)
-    write_hubverse_nowcasts(
+    write_hubverse_nowcast(
         pipeline_workspace,
+        disease=disease,
+        location=location,
         nhsn_observations=selected_nhsn_observations(disease, location),
-        locations=[location],
-        diseases=[disease],
     )
     hubverse_nowcast_dir = (
         pipeline_workspace / "private_data" / HUBVERSE_NOWCAST_DIR_NAME / disease

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -4,6 +4,10 @@ from pathlib import Path
 
 import polars as pl
 import pytest
+from tests.integration.generate_test_data import (
+    DEFAULT_DISEASES,
+    DEFAULT_LOCATIONS,
+)
 from tests.integration.model_test_utils import (
     EXCLUDE_LAST_N_DAYS,
     FORECAST_DIR_NAME,
@@ -16,10 +20,6 @@ from tests.integration.model_test_utils import (
     run_pyrenew,
 )
 
-from cfa.stf.routine.data.generate_test_data import (
-    DEFAULT_DISEASES,
-    DEFAULT_LOCATIONS,
-)
 from cfa.stf.routine.utils.directory_utils import parse_model_batch_dir_name
 from cfa.stf.routine.utils.postprocess_forecast_batches import (
     main as postprocess_batches,

--- a/uv.lock
+++ b/uv.lock
@@ -752,7 +752,7 @@ dev = [
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "jupyter" },
-    { name = "matplotlib" },
+    { name = "plotnine" },
     { name = "pre-commit" },
     { name = "py-yaml12" },
     { name = "pytest" },
@@ -761,7 +761,7 @@ dev = [
     { name = "rich" },
 ]
 test = [
-    { name = "matplotlib" },
+    { name = "plotnine" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mpl" },
@@ -796,7 +796,7 @@ dev = [
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "jupyter", specifier = ">=1.0.0" },
-    { name = "matplotlib", specifier = ">=3.11.1" },
+    { name = "plotnine", specifier = ">=0.15.3" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "py-yaml12" },
     { name = "pytest", specifier = ">=8.3.2" },
@@ -805,7 +805,7 @@ dev = [
     { name = "rich" },
 ]
 test = [
-    { name = "matplotlib", specifier = ">=3.11.1" },
+    { name = "plotnine", specifier = ">=0.15.3" },
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },
@@ -1493,6 +1493,24 @@ wheels = [
 ]
 
 [[package]]
+name = "formulaic"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "interface-meta" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/87/e7b9b39d218793f159d7425e264c0ac196da07f1decc333001502fac02fb/formulaic-1.2.2.tar.gz", hash = "sha256:c99e8f11ff7d327eaecaf63855ca69b7fa0da100ad6c0041ef80912fbac667e6", size = 657522, upload-time = "2026-06-02T18:24:42.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl", hash = "sha256:0f84ff49e3fc9dc0e68ab08a0a9427874021aa6c558e66b44dc634a35739b09b", size = 118939, upload-time = "2026-06-02T18:24:41.344Z" },
+]
+
+[[package]]
 name = "fqdn"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1789,6 +1807,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "interface-meta"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/5b/202a48a1ccdef721a95357fbe263c54ef87c18c4972df1ab5c22fe0f33d5/interface_meta-2.0.1.tar.gz", hash = "sha256:902bd9a95a12f195f15753a1080075d4eca7a2cb934fac7ac03c9e362b50796a", size = 15281, upload-time = "2026-04-30T22:35:36.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl", hash = "sha256:f38016bef9a4429b6d0792d809be7b65e9781820c674bf7f463999086b6e6323", size = 15330, upload-time = "2026-04-30T22:35:35.201Z" },
 ]
 
 [[package]]
@@ -2432,6 +2459,21 @@ wheels = [
 ]
 
 [[package]]
+name = "mizani"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/02/43fcf763c70e8aa8edc28ac65713daca2c18d3bc2b998af4647966b5bafb/mizani-0.14.4.tar.gz", hash = "sha256:28934d91516d922d7cb0382c82a6c513692abc0174c42a50294ae571520633f9", size = 772490, upload-time = "2026-01-28T14:42:18.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/30/b6617c74a8234ff60265373ef730eb6378ccdda74042f51f9ac936191664/mizani-0.14.4-py3-none-any.whl", hash = "sha256:ed72bf249e2a18b5dcc65cd54c7eaa5444b2cb09c7e18aafa2ab6f05f1b78620", size = 133471, upload-time = "2026-01-28T14:42:16.328Z" },
+]
+
+[[package]]
 name = "ml-dtypes"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2550,6 +2592,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
 ]
 
 [[package]]
@@ -3077,11 +3128,24 @@ wheels = [
 ]
 
 [[package]]
+name = "patsy"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/e3/950e513affdfe1c1864397b4f40d6ed06ec1b54f608e462c27f151dd72df/patsy-1.0.3.tar.gz", hash = "sha256:79ebf4c93ff4d296e58a9d5be2b2ee31bd49d737cf11d70ffbd8a44b2de42e65", size = 399992, upload-time = "2026-08-29T21:35:32.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/70/cd3cf5cff538323076a879edef02cce6f13f7d75e03d12f211b0a0dbd178/patsy-1.0.3-py2.py3-none-any.whl", hash = "sha256:d3dbebe8fd5f46e29912d030b63c6268647b59bf788a99e2af28a30234cf357c", size = 233318, upload-time = "2026-08-29T21:35:30.913Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3115,6 +3179,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/b7/802a56eca9f2fac455b8bab5375a2647b0f0e14a2cd63ef077de3c4a7658/platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d", size = 35127, upload-time = "2026-09-01T13:35:10.502Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6", size = 23938, upload-time = "2026-09-01T13:35:09.02Z" },
+]
+
+[[package]]
+name = "plotnine"
+version = "0.15.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "mizani" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "statsmodels", version = "0.14.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "statsmodels", version = "0.15.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/5d/3471689cf15cf2b6ebb6ebdebc7e33831fb35d85e2323875b5a0e150505d/plotnine-0.15.8.tar.gz", hash = "sha256:d3859997c3abd6edff6dee376d912716e75bbe0b0099b7054176d84fe11e8e20", size = 6863148, upload-time = "2026-08-14T16:27:49.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/37/7a0275ea8143f0f0a2b27db73656d7ea3459e9cf8f869e292e450b357d1e/plotnine-0.15.8-py3-none-any.whl", hash = "sha256:b8a17fbccdf331f0474ff59ea03186c07d96586eb0ebe70121b03fbf131881a9", size = 1573224, upload-time = "2026-08-14T16:27:47.601Z" },
 ]
 
 [[package]]
@@ -4041,6 +4123,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform == 'emscripten'",
+]
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/3b/963a015dd8ea17e10c7b0e2f14d7c4daec903baf60a017e756b57953a4bf/statsmodels-0.14.4.tar.gz", hash = "sha256:5d69e0f39060dc72c067f9bb6e8033b6dccdb0bae101d76a7ef0bcc94e898b67", size = 20354802, upload-time = "2024-10-03T16:15:36.273Z" }
+
+[[package]]
+name = "statsmodels"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "formulaic" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/1f/a3cbf6ed7cf6286afec694bfef561f3e51483197716717fb8476f1f0c50e/statsmodels-0.15.0.tar.gz", hash = "sha256:5d257fe58d0772bc46a557880ca78e2a8e07fec7bfd9d11074aef8e33e1aecbc", size = 15736853, upload-time = "2026-08-27T10:45:21.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/17/fee8cfc100c37b1c553515dbad59607a55085a5b9beac2b008e4c03b6388/statsmodels-0.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09fe34ac80e147cd76cb702ba672559ee3c5dd3ba15c25a232922b46e5ffe70e", size = 11696848, upload-time = "2026-08-27T10:36:13.782Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/60/a885751cd3aa796ef94b60f6d3de0c9ace4190feb3e55414ee728d2a0abc/statsmodels-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ffe08752f420f12a0b03e8f7d8f3a45417615309b1f37f10561f9a53f044737", size = 11556170, upload-time = "2026-08-27T10:36:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f4/482701d2dc7540897b13ead827cf8499b11c7325753b8cc4ff1a82c87a18/statsmodels-0.15.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a7ab98634d47048c6b7c168b3f8f71369e256d7314bc386168526f34c7699d7", size = 11752604, upload-time = "2026-08-27T10:47:50.809Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/88/5c8819f232448d52514b76a64cf285bc608cff9179f3eeacf58750612323/statsmodels-0.15.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcaa1e4499697c4e023e5fa6fb04459a34e4f4a449c45ae441992e933bde24db", size = 12055386, upload-time = "2026-08-27T10:49:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/19/a8/298e9b5c993cad3b58913d61b7e7cb0e2fba12e39d3114cd8484f922a5d1/statsmodels-0.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:88dbe345ecf317862481b3c86305f42133082e5b366a3a8cf240a6caac404daf", size = 12088356, upload-time = "2026-08-27T10:48:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f5/386c6cfda27c47df81643dc9466b3e28dc2a82152e524131977275a88e0c/statsmodels-0.15.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:ac9bce461d0c8f529f8ed331a469eaa5dd7c3213c06b62623a2e5438a6383093", size = 9809418, upload-time = "2026-08-27T10:36:50.646Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b4/a8a4d89918599309bebfc09a2f793a910279f3900671bc959ac8c810edd1/statsmodels-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:081adf7e5f2da63f63cbd90491447de5d4c4c2921f19814f235bcf3e736edd3c", size = 11312877, upload-time = "2026-08-27T10:37:08.325Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/79/66b57afdcbf9a8b21b1a8e4414ddb006e819b2a81243cd74c12f3301eca3/statsmodels-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3e5f870037ca154a4d177aeac68704a784b24cf2c45d86b046fc28e37a2a5584", size = 10812282, upload-time = "2026-08-27T10:37:26.708Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -752,6 +752,7 @@ dev = [
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "jupyter" },
+    { name = "matplotlib" },
     { name = "pre-commit" },
     { name = "py-yaml12" },
     { name = "pytest" },
@@ -760,6 +761,7 @@ dev = [
     { name = "rich" },
 ]
 test = [
+    { name = "matplotlib" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mpl" },
@@ -794,6 +796,7 @@ dev = [
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "jupyter", specifier = ">=1.0.0" },
+    { name = "matplotlib", specifier = ">=3.11.1" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "py-yaml12" },
     { name = "pytest", specifier = ">=8.3.2" },
@@ -802,6 +805,7 @@ dev = [
     { name = "rich" },
 ]
 test = [
+    { name = "matplotlib", specifier = ">=3.11.1" },
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mpl", specifier = ">=0.17.0" },


### PR DESCRIPTION
## Why

The EpiAutoGP integration test previously generated Hubverse nowcasts on fixed synthetic dates. In real-data mode, those dates could extend beyond the NHSN observations selected for the run, violating the requirement that every nowcast date have a corresponding observation. The test fixture should instead be conditional on the same selected observations used to fit the model.

## What changed

- derive Hubverse target dates and baseline values from the selected NHSN observations, retaining at least two earlier observations for model fitting and nowcasting at most the four most recent eligible dates
- simulate plausible upward revisions with mean `y_t (1 + r_t)`, where `r_t` increases linearly from 1% to 10% toward the present, and mean-one multiplicative lognormal noise supplies sample uncertainty
- save a diagnostic PNG beside the generated Parquet showing every simulated nowcast trajectory, their mean, and the selected raw NHSN observations
- write the single disease/location Hubverse artifact required by an integration run through a singular API, removing unused multi-disease and multi-location assembly layers
- keep synthetic surveillance generation, Hubverse fixture construction, and diagnostic plotting in the test package rather than the production `cfa.stf.routine` package
- exercise NHSN epiweekly observed data with Hubverse nowcasts, NSSP daily observed ED visits with reporting-delay nowcasting, and NSSP daily other ED visits with no nowcasting
- migrate the EpiAutoGP Justfile recipes from `dmb/streamline-data-pivoting`

## Testing

- `just test` — 169 passed
- `just test-epiautogp real` — passed
- `just test-epiautogp mock` — passed
- focused Hubverse/test-data tests — 25 passed
- pre-commit checks on all changed files — passed
