### PR TITLE
Upgrade cfa-dagster remove now-unnecessary root dagster_defs.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Project files
 COPY src ./src
 COPY README.md ./README.md
-COPY dagster_defs.py ./dagster_defs.py
 
 # Install the local project now that its sources are present
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/dagster_defs.py
+++ b/dagster_defs.py
@@ -1,9 +1,0 @@
-"""Compatibility entrypoint for tooling that expects definitions at repo root."""
-
-from cfa_dagster import start_dev_env
-
-start_dev_env(__name__)
-
-from cfa.stf.routine.dagster_defs import defs  # noqa: E402
-
-__all__ = ["defs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ show_missing = true
 skip_covered = true
 
 [tool.uv.sources]
-cfa-dagster = { git = "https://github.com/cdcgov/cfa-dagster", rev = "v1.4.3" }
+cfa-dagster = { git = "https://github.com/cdcgov/cfa-dagster", rev = "v1.5.0" }
 cfa-cloudops = { git = "https://github.com/CDCgov/cfa-cloudops.git" }
 pyrenew-multisignal = {git = "https://github.com/CDCgov/pyrenew-multisignal", rev = "1c9fa48"}
 polarbayes = { git = "https://github.com/cdcgov/polarbayes", rev = "main" }

--- a/src/cfa/stf/routine/dagster_defs.py
+++ b/src/cfa/stf/routine/dagster_defs.py
@@ -25,6 +25,7 @@ from cfa_dagster import (
     docker_executor,
     dynamic_executor,
     dynamic_graph_asset,
+    start_dev_env,
 )
 from cfa_dagster import (
     is_production as is_prod,
@@ -63,6 +64,8 @@ warnings.filterwarnings(
 user = os.getenv("DAGSTER_USER")
 
 is_production = is_prod()
+
+start_dev_env(__name__)
 
 # ============================================================================
 # RUNTIME CONFIGURATION: WORKING DIRECTORY, EXECUTORS, VOLUME MOUNTS

--- a/uv.lock
+++ b/uv.lock
@@ -719,8 +719,8 @@ dependencies = [
 
 [[package]]
 name = "cfa-dagster"
-version = "1.4.3"
-source = { git = "https://github.com/cdcgov/cfa-dagster?rev=v1.4.3#82ce0439d7fa6d7686978582b5c27dce4358a60b" }
+version = "1.5.0"
+source = { git = "https://github.com/cdcgov/cfa-dagster?rev=v1.5.0#dbec802ca926d2fa73c6cf5a040a5501958d1976" }
 dependencies = [
     { name = "aiofiles" },
     { name = "azure-batch" },
@@ -850,7 +850,7 @@ test = [
 requires-dist = [
     { name = "arviz", extras = ["h5netcdf"], specifier = ">=1.3.0" },
     { name = "cfa-cloudops", git = "https://github.com/CDCgov/cfa-cloudops.git" },
-    { name = "cfa-dagster", git = "https://github.com/cdcgov/cfa-dagster?rev=v1.4.3" },
+    { name = "cfa-dagster", git = "https://github.com/cdcgov/cfa-dagster?rev=v1.5.0" },
     { name = "cfa-stf-data", git = "https://github.com/CDCgov/cfa-stf-data?rev=v0.2.0" },
     { name = "cfa-stf-forecasttools", git = "https://github.com/CDCgov/cfa-stf-forecasttools?rev=main" },
     { name = "jax" },
@@ -871,7 +871,7 @@ dagster-config-editor = [
     { name = "rich" },
 ]
 dev = [
-    { name = "cfa-dagster", extras = ["dev"], git = "https://github.com/cdcgov/cfa-dagster?rev=v1.4.3" },
+    { name = "cfa-dagster", extras = ["dev"], git = "https://github.com/cdcgov/cfa-dagster?rev=v1.5.0" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "jupyter", specifier = ">=1.0.0" },


### PR DESCRIPTION
The purpose of this PR is to upgrade `cfa-dagster` so the stub `dagster_defs.py` file can be removed from the root of the repo. There are a couple of other quality of life upgrades included in the latest `cfa-dagster` including:
- metadata for configured graph dimensions
- metadata for materialized graph dimensions including percentage materialized vs. total
- better hot reloading
See the [release page](https://github.com/CDCgov/cfa-dagster/releases/tag/v1.5.0) for more details

I was able to deploy this image as a code location and confirm that [running](https://dagster.apps.edav.ext.cdc.gov/runs/1f1842b5-b994-4581-82d2-cbc11fdd6197) `pyrenew_e` and `fable_e_other` with just `AL` would trigger just `AL` [downstream](https://dagster.apps.edav.ext.cdc.gov/runs/40b7fa9d-0ef1-417f-b3c3-6bd2af2f7b15) in `fuse_pyrenew_e_ts`:
<img width="1650" height="340" alt="image" src="https://github.com/user-attachments/assets/72dcd9fa-24d9-495f-a3dc-5067131516a5" />

I can also see the slick new metadata to keep track of what was last materialized:
<img width="535" height="553" alt="image" src="https://github.com/user-attachments/assets/76c69c7a-6eba-4a45-97aa-2072f4741fbd" />

